### PR TITLE
fix(retrieval): name embedder URL on connect failure, stop blaming qdrant

### DIFF
--- a/src/retrieval/embedder.rs
+++ b/src/retrieval/embedder.rs
@@ -210,7 +210,22 @@ impl EmbedderHttp {
         let resp: OpenAiEmbedResp = req
             .send()
             .await
-            .context("dense openai send")?
+            .map_err(|e| {
+                // A connect/timeout failure is client-side: the embedder URL is
+                // wrong or the service is down. Lift the URL + a "connect" marker
+                // to the top-level message so `e.to_string()` (what the search
+                // layer's classifier sees) routes this to the embedder hint
+                // instead of the misleading "check qdrant logs" fallback.
+                if e.is_connect() || e.is_timeout() {
+                    anyhow!(
+                        "dense embed connect failed: {url} — the dense embedder is \
+                         unreachable (connect/timeout). Check CODESCOUT_EMBEDDER_URL and \
+                         that the embedder is running (`./scripts/retrieval-stack.sh ps`). ({e})"
+                    )
+                } else {
+                    anyhow::Error::new(e).context("dense openai send")
+                }
+            })?
             .error_for_status()
             .context("dense openai status")?
             .json()
@@ -441,6 +456,29 @@ impl EmbedderHttp {
 #[async_trait::async_trait]
 pub trait DenseEmbedder: Send + Sync {
     async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A dense connect failure must name the target URL and flag "connect" so
+    /// the search-layer classifier routes it to the embedder hint (not qdrant).
+    /// Port 1 refuses connections instantly, keeping the test hermetic.
+    #[tokio::test]
+    async fn dense_connect_failure_names_url_and_flags_connect() {
+        let e = EmbedderHttp::with_config("http://127.0.0.1:1", "http://127.0.0.1:1", 768, "m", "");
+        let err = e.dense_query("hello").await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("http://127.0.0.1:1"),
+            "connect error must name the target URL; got: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("connect"),
+            "must flag a connect failure so the classifier can route it; got: {msg}"
+        );
+    }
 }
 
 /// Production [`DenseEmbedder`] backed by the HTTP retrieval stack.

--- a/src/tools/semantic/semantic_search.rs
+++ b/src/tools/semantic/semantic_search.rs
@@ -9,7 +9,13 @@ use serde_json::{json, Value};
 /// Patterns are checked in order of specificity: collection-missing first
 /// (most common after first-time setup), then dim-mismatch (model/index
 /// drift), then TEI errors (dense embedding service unhealthy), then
+/// embedder-connect (client-side: dense/sparse endpoint unreachable), then
 /// transport (stack went away), then a generic fallback.
+///
+/// The embedder-connect bucket must precede transport: a client-side connect
+/// failure's message carries reqwest's "Connection refused", which would
+/// otherwise be misrouted to the qdrant-oriented transport hint
+/// (docs/issues/2026-07-13-semantic-search-misleading-stack-error-on-missing-env.md).
 pub(crate) fn classify_search_error(err_str: &str, project_id: &str) -> String {
     if err_str.contains("doesn't exist")
         || err_str.contains("not found")
@@ -36,6 +42,19 @@ pub(crate) fn classify_search_error(err_str: &str, project_id: &str) -> String {
          Restart: `./scripts/retrieval-stack.sh up`. \
          If persistent, inspect container memory limits + model file. \
          Workaround: fall back to `grep` / `symbols` for this query while TEI recovers."
+            .to_string()
+    } else if err_str.contains("embed connect failed")
+        || err_str.contains("openai send")
+        || err_str.contains("embed sparse")
+    {
+        // Client-side: the query could not be embedded because the embedder
+        // endpoint is unreachable/erroring. Distinct from a Qdrant fault —
+        // must NOT send the operator to qdrant logs (the 2026-07-13 bug).
+        "Query could not be embedded — the dense/sparse embedder is unreachable \
+         or returned an error. This is an embedder problem, NOT a Qdrant issue \
+         (don't check qdrant logs). Verify CODESCOUT_EMBEDDER_URL / \
+         CODESCOUT_SPARSE_EMBEDDER_URL point at the running embedder, then \
+         `./scripts/retrieval-stack.sh ps`."
             .to_string()
     } else if err_str.contains("Connection refused")
         || err_str.contains("transport error")
@@ -464,6 +483,39 @@ mod classify_search_error_tests {
         assert!(
             !hint.contains("Stack reachable but query failed"),
             "must not hit generic fallback: {hint}"
+        );
+    }
+
+    #[test]
+    fn dense_connect_failure_routes_to_embedder_hint_not_qdrant() {
+        // Regression: a client-side connect failure (wrong CODESCOUT_EMBEDDER_URL
+        // or embedder down) used to fall through to the generic "check qdrant
+        // logs" fallback, sending operators to debug a healthy stack. See
+        // docs/issues/2026-07-13-semantic-search-misleading-stack-error-on-missing-env.md.
+        let err = "stack search failed: dense embed connect failed: \
+                   http://127.0.0.1:8081/v1/embeddings — the dense embedder is unreachable";
+        let hint = classify_search_error(err, "codescout");
+        assert!(
+            hint.contains("CODESCOUT_EMBEDDER_URL"),
+            "hint must point at the embedder URL env var: {hint}"
+        );
+        // The regression marker is the generic fallback's qdrant directive; our
+        // hint may *mention* qdrant (to steer away from it), so match the precise
+        // fallback text rather than the bare substring "qdrant logs".
+        assert!(
+            !hint.contains("docker logs codescout-qdrant")
+                && !hint.contains("Stack reachable but query failed"),
+            "must NOT route a client-side connect failure to the qdrant-logs fallback: {hint}"
+        );
+    }
+
+    #[test]
+    fn openai_send_does_not_hit_generic_qdrant_fallback() {
+        let err = "stack search failed: dense openai send";
+        let hint = classify_search_error(err, "codescout");
+        assert!(
+            !hint.contains("Stack reachable but query failed"),
+            "a dense send failure must route to the embedder bucket, not the generic fallback: {hint}"
         );
     }
 }


### PR DESCRIPTION
## Problem
When the dense embedder is unreachable (wrong `CODESCOUT_EMBEDDER_URL`, or the service is down), `semantic_search` failed with `stack search failed: dense openai send` and a hint telling operators to *"check qdrant logs"* — sending them to debug a healthy Qdrant. The fault is client-side.

## Changes
- **`src/retrieval/embedder.rs`** — `dense_batch` maps `is_connect()`/`is_timeout()` errors to a top-level message naming the target URL + a `connect` marker. Non-connect send errors keep the old `dense openai send` context.
- **`src/tools/semantic/semantic_search.rs`** — `classify_search_error` gains an embedder-connect bucket, ordered **before** the transport bucket (the new message carries reqwest's "Connection refused", which the qdrant transport bucket would otherwise grab). It points at `CODESCOUT_EMBEDDER_URL` / `CODESCOUT_SPARSE_EMBEDDER_URL`, not qdrant.

## Why lift the info to the top-level message
The search layer classifies on `e.to_string()` (Display), which drops the source chain where reqwest's URL/connect detail lives. Lifting a `connect` marker + the URL to the top makes the error both human-useful and machine-classifiable through that bottleneck.

## Tests (TDD)
- `retrieval::embedder::tests::dense_connect_failure_names_url_and_flags_connect` — hermetic (dead port `:1`)
- `classify_search_error_tests::dense_connect_failure_routes_to_embedder_hint_not_qdrant`
- `classify_search_error_tests::openai_send_does_not_hit_generic_qdrant_fallback`

Full suite green; the 7 pre-existing classifier tests are unaffected.

Fixes the misleading-error bug in `docs/issues/2026-07-13-semantic-search-misleading-stack-error-on-missing-env.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
