### PR TITLE
docs(issues): the .gitignore projects-tree rule rests on a premise that is false on a dev host

### DIFF
--- a/docs/issues/2026-08-08-gitignore-projects-rule-premise-false-on-a-real-host.md
+++ b/docs/issues/2026-08-08-gitignore-projects-rule-premise-false-on-a-real-host.md
@@ -9,7 +9,7 @@ tags: [gitignore, repo-hygiene, workspace]
 kind: bug
 ---
 
-# BUG: the `/.codescout/projects/` ignore decision rests on a premise that is false on any host with registered foreign workspaces
+# BUG: the `/.codescout/projects/` ignore comment's "no untracked content" clause holds only in a fresh clone or CI — and the dirs behind it come from an unvalidated project id
 
 ## Summary
 
@@ -50,9 +50,16 @@ Fresh clones and CI show nothing, which is why the premise reads true from there
 
 ## Environment
 
-`experiments` at `88316ac9`, Windows VDI, codescout MCP with eight foreign workspaces
-registered (four repos in the `codescout-ecosystem` umbrella plus four unrelated).
+`experiments` at `88316ac9`, Windows VDI, codescout MCP with eight entries present under
+`.codescout/projects/`: `Mercury BOM`, `Mercury MRP Automation`, `codescout`,
+`m365-data-agent`, `m365-mcp`, `researcher`, `servicenow-mcp`, `web`. None of them is a
+subdirectory of the codescout checkout, and only `codescout` and `researcher` correspond to
+anything the operator works in regularly — `researcher` is not a `codescout-ecosystem`
+umbrella member, and no umbrella member other than codescout itself appears. See the review
+addendum below for what actually creates these.
 
+Contrast host: Linux, `9cbe4002`, same operator, same registry, nine repos with a
+`.codescout/projects/` tree — zero untracked entries in any of them.
 ## Root cause
 
 Two different populations share one directory, and the rule was written against only one
@@ -123,24 +130,125 @@ rules are wrong in opposite directions; neither population is served by a single
    (`Root: work\Mercury BOM`). They are per-operator, not per-repo.
    **Verdict:** rejected.
 
+## Review addendum — cross-host sweep and re-diagnosis (2026-08-08)
+
+Added by the review pass that owns `6f261da9`. The observation above is real and the
+third-clause correction is accepted. The **diagnosis** is wrong, and it aims the fix at
+the wrong layer.
+
+### The sweep: nine repos, zero `??`
+
+Every root registered in `~/.config/librarian/workspace.toml` — 10 `[[roots]]` plus both
+umbrellas, 15 paths — checked on the Linux host at `9cbe4002`:
+
+| repo | `projects/` entries | tracked | `??` | why it is clean |
+|---|---|---|---|---|
+| codescout | 9 fixtures | 53 | 0 | no ignore rule; nothing generated lands there |
+| `~/personal` | `personal` | 10 | 0 | structural allow-list (see Fix) |
+| mirela/backend-kotlin | 5 | 27 | 0 | all content tracked |
+| eudis | 13 | 0 | 0 | blanket `.codescout/` |
+| wingman | 8 | 0 | 0 | blanket `.codescout/` |
+| claude-plugins | `buddy`, `mcp-server` | 0 | 0 | blanket `.codescout/` |
+| mirela/eduplanner-site | `optaplanner` | 0 | 0 | the directory is **empty** |
+
+No `projects/` tree at all: `prompt-engineering`, `llm-proxy`, `RAG-reranker`,
+`smart-promoter`, `claude-code`, `mirela/deployment`, `eduplanner-mobile`,
+`eduplanner-ui`. Not git repos (container directories): `mirela`, `southpole`,
+`invest-europe`. Dead registry entry: `code-explorer` points at a path that no longer
+exists.
+
+**Total untracked entries under `.codescout/projects/` across every registered root: 0.**
+
+So "the normal state for the cross-project flows CLAUDE.md documents" does not hold —
+nine repos run exactly those flows and produce no `??` at all. The VDI is an outlier, not
+the baseline.
+
+### The phantom directories are here too, and they are empty
+
+`.codescout/projects/<id>/` exists for ids that are **not** subdirectories of their repo:
+
+- `claude-plugins/.codescout/projects/mcp-server/` — no `mcp-server` directory exists in
+  that repo. Empty.
+- `mirela/eduplanner-site/.codescout/projects/optaplanner/` — `optaplanner` is a
+  **sibling** at `mirela/optaplanner`, not a child. Empty.
+
+Git cannot see an empty directory. That, not the absence of the mechanism, is why this
+host looks clean.
+
+### The actual root cause
+
+`Workspace::memory_dir_for_project` resolves any id that is not the root project into
+`self.root/.codescout/projects/<id>/memories`, and its own docstring states the behavior
+is deliberate:
+
+> An unknown `project_id` is treated as a sub-project (returns a per-project subdirectory
+> under `projects/<id>/`). Previously defaulted to the root memory dir on unknown ID,
+> which silently co-mingled memories from typos or stale IDs …
+
+The id is validated against nothing. Any string — a stale id, a typo, a foreign workspace
+name — materializes a directory under the *active* workspace's root. The two empty
+directories above are that mechanism caught in the act. On the VDI something additionally
+*wrote* stubs into them, which is the only reason they became visible to `git status`.
+
+Two independent tells in the original evidence agree. `Root: work\Mercury BOM` occupies
+the same field as this repo's `Root: tests/fixtures/rust-library` — a *relative
+sub-project root*. And `.codescout/projects/codescout/` can only exist when the project
+whose id is `codescout` has `relative_root != "."`, which contradicts the checked-in
+`.codescout/workspace.toml` (`[[project]] id = "codescout", root = "."`).
+
+So the two populations are not "fixtures vs. foreign workspaces". They are "real
+sub-projects" and "directories conjured by an unvalidated id". The second should not exist
+at all, which is why no glob can cleanly describe it.
+
+### Two corrections to the report above
+
+- `## Environment` claims the eight are "four repos in the `codescout-ecosystem` umbrella
+  plus four unrelated". The umbrella is codescout, prompt-engineering, claude-plugins,
+  llm-proxy. The listed eight include `codescout` and `researcher` but none of
+  prompt-engineering, claude-plugins, or llm-proxy — and `researcher` is not a member.
+- The cited tip `88316ac9` is two commits stale, and the untracked set is exactly the
+  thing that moves between commits.
+
 ## Fix
 
-Not yet applied — the choice belongs to whoever owns the `6f261da9` stance.
+Two layers, in this order.
 
-- **Option A (narrow, no policy change):** ignore the eight by name. Honest, zero risk to
-  the fixture files, and stale the moment a ninth workspace is registered.
-- **Option B (structural):** `/.codescout/projects/*/` plus `!` re-includes for the nine
-  fixture projects. Self-maintaining for new workspaces and it keeps future fixture
-  memories visible — but it re-adopts a blanket rule over the tree, which is the thing
-  `6f261da9` argued against, so it needs that author's sign-off.
-- **Option C (root fix, largest):** stop co-locating generated foreign-workspace state
-  with authored fixture memories — write registered-workspace stubs somewhere already
-  ignored. Removes the need for any glob gymnastics.
+**1 — Upstream, the real fix.** Validate `project_id` in
+`Workspace::memory_dir_for_project`. An id that is neither the root project nor a declared
+or discovered sub-project of this workspace should be an error, not a freshly created
+directory. Filed separately as
+`docs/issues/2026-08-08-memory-dir-for-project-materializes-any-id.md`.
 
-Whichever lands, the `.gitignore` comment needs its third clause corrected: the tree
-**does** hold untracked generated content on a developer host, and that is exactly why
-the rule is hard to write.
+**2 — Belt and braces in `.gitignore`.** Use the structural pattern already running in the
+operator's `~/personal` repo. It is strictly better than Options A/B/C below:
 
+```gitignore
+/.codescout/*
+!/.codescout/memories/
+!/.codescout/projects/
+/.codescout/projects/*/*
+!/.codescout/projects/*/memories/
+```
+
+It enumerates no ids, so it never goes stale; it keeps **every** project's `memories/`
+visible, including projects that do not exist yet; and it ignores anything generated that
+lands elsewhere under the tree. Verified non-destructive on 2026-08-08 —
+`find .codescout/projects -type f -not -path '*/memories/*'` returns nothing, so all 53
+tracked files sit inside a `memories/` directory and survive the pattern intact.
+
+The three original options are superseded:
+
+- **A** (ignore the eight by name) — stale on the ninth workspace, by its own admission.
+- **B** (`projects/*/` plus `!` re-includes for the nine fixture ids) — **rejected.**
+  Enumerating ids reintroduces exactly what `6f261da9` removed: a rule that silently hides
+  the tenth fixture project. The structural pattern above is the version of B that works,
+  because it re-includes by *shape* rather than by name.
+- **C** (relocate generated foreign-workspace state) — right instinct, wrong premise. There
+  is no foreign-workspace-state feature to relocate; there is an unvalidated id to reject.
+  That is fix 1.
+
+The `.gitignore` comment's third clause still needs the correction this report asks for:
+the tree holds no untracked content **in a fresh clone or in CI** — not "at all".
 ## Tests added
 
 None. A `.gitignore` policy has no unit-test surface, and the failure is environmental —
@@ -155,14 +263,26 @@ add the eight to `.git/info/exclude`, which is per-clone and commits nothing.
 
 ## Resume
 
-Pick between Options A/B/C above with the author of `6f261da9`, then apply it together
-with the comment correction in `.gitignore` (the `Deliberately NOT` block, lines ~72-79).
-Re-check the untracked set first — `git status --porcelain .codescout/projects` — since
-it grows with every workspace activated since 2026-08-08.
+Fix 1 is the load-bearing one and is tracked in its own bug file — do not close this one on
+the `.gitignore` change alone.
 
+1. On the **VDI**, before anything else: run `project_status` there and compare each
+   project's `relative_root` against the workspace `root`. That says whether the eight are
+   unvalidated ids (expected) or genuine mis-discovery, and it is not reproducible from the
+   Linux host.
+2. Apply fix 2 (the structural `.gitignore` pattern) plus the third-clause comment
+   correction in the `Deliberately NOT` block, in one commit.
+3. Re-check `git status --porcelain .codescout/projects` on both hosts afterwards. On Linux
+   it was already empty, so the pattern must not *change* anything there — that is the
+   regression check.
+4. Do not re-propose Option B in its id-enumerating form; it is rejected above with reasons.
 ## References
 
 - `6f261da9` — the review-pass commit that set the current rule (finding 5)
 - `49a1e1ac` — the blanket rule it replaced
 - `.gitignore` lines ~72-80
+- `src/workspace.rs` — `Workspace::memory_dir_for_project`, the unvalidated-id site
+- `docs/issues/2026-08-08-memory-dir-for-project-materializes-any-id.md` — the upstream bug
+- `~/.config/librarian/workspace.toml` — the registry the cross-host sweep enumerated
 - PR https://github.com/mareurs/codescout/pull/10
+- PR https://github.com/mareurs/codescout/pull/11 — this file, and the review addendum

--- a/docs/issues/2026-08-08-gitignore-projects-rule-premise-false-on-a-real-host.md
+++ b/docs/issues/2026-08-08-gitignore-projects-rule-premise-false-on-a-real-host.md
@@ -1,0 +1,168 @@
+---
+status: open
+opened: 2026-08-08
+closed:
+severity: low
+owner: marius
+related: []
+tags: [gitignore, repo-hygiene, workspace]
+kind: bug
+---
+
+# BUG: the `/.codescout/projects/` ignore decision rests on a premise that is false on any host with registered foreign workspaces
+
+## Summary
+
+`6f261da9` dropped the blanket `/.codescout/projects/` ignore rule, correctly, because
+53 tracked memory files live under that tree. Its justification also asserts the path
+"has no untracked content at all". On this host it has eight untracked directories of
+auto-generated content, so `git status` now carries eight permanent `??` entries — the
+same noise-blindness the change was avoiding, arriving from the other side.
+
+## Symptom (Effect)
+
+`git status --porcelain .codescout/projects` on `experiments` at `88316ac9`:
+
+```
+?? ".codescout/projects/Mercury BOM/"
+?? ".codescout/projects/Mercury MRP Automation/"
+?? .codescout/projects/codescout/
+?? .codescout/projects/m365-data-agent/
+?? .codescout/projects/m365-mcp/
+?? .codescout/projects/researcher/
+?? .codescout/projects/servicenow-mcp/
+?? .codescout/projects/web/
+```
+
+Permanent, and they crowd the working-tree noise floor that the ignore file exists to
+keep clear.
+
+## Reproduction
+
+On a checkout where codescout has activated any workspace outside this repo:
+
+```
+git checkout experiments   # 88316ac9 or later
+git status --porcelain .codescout/projects
+```
+
+Fresh clones and CI show nothing, which is why the premise reads true from there.
+
+## Environment
+
+`experiments` at `88316ac9`, Windows VDI, codescout MCP with eight foreign workspaces
+registered (four repos in the `codescout-ecosystem` umbrella plus four unrelated).
+
+## Root cause
+
+Two different populations share one directory, and the rule was written against only one
+of them.
+
+- **Tracked (53 files, 9 projects):** `codescout-embed`, `edit-eval-rust`,
+  `java-library`, `kotlin-library`, `librarian-mcp`, `nav-eval-rust`, `python-library`,
+  `rust-library`, `typescript-library`. All are **in-repo fixtures** (`tests/fixtures/*`,
+  `crates/*`) with hand-authored memories maintained by `chore(memories):` commits. These
+  are what `6f261da9` protected, and protecting them is right.
+- **Untracked (8 dirs):** the operator's **foreign workspaces**, registered on this
+  machine. Their contents are machine-generated stubs, not authored — e.g.
+  `.codescout/projects/Mercury BOM/memories/onboarding.md`, 100 bytes, whole file:
+
+  ```
+  Languages: python, markdown, bash, css, javascript
+  Root: work\Mercury BOM
+  Manifest: requirements.txt
+  ```
+
+  Written 2026-07-13 by activation, never edited by hand, and regenerable.
+
+So "that path has no untracked content at all" is true of a fresh clone and of CI, and
+false of any developer machine that has activated a workspace elsewhere — which is the
+normal state for the cross-project flows CLAUDE.md documents. Measured 2026-08-08:
+`git ls-files .codescout/projects` → 53, all fixtures; `git status --porcelain
+.codescout/projects` → 8, all foreign.
+
+The deeper shape: the tree has no naming or structural boundary between authored and
+generated content, so no single glob can express the intent. The comment's confident
+absolute is a symptom of that, not sloppiness — it was checked against the only
+environment where the question looks settled.
+
+## Evidence
+
+### The rule and its justification, `6f261da9`
+
+```
+-# Local codescout search index + per-project caches (regenerated on activate)
++# Local codescout search index (regenerated on activate).
++#
++# Deliberately NOT `/.codescout/projects/`: that tree holds 53 tracked,
++# hand-authored per-project memory files (`*/memories/*.md`, `*.anchors.toml`)
++# maintained by explicit `chore(memories):` commits. Ignoring it would not
++# untrack those, but it would hide every future one from `git status` with no
++# error — and it shadows no cache, since that path has no untracked content at
++# all. The index DB below is the thing that is actually regenerated.
+ /.codescout/code-index.db
+-/.codescout/projects/
+```
+
+The first two clauses are correct and load-bearing. Only the third clause is wrong.
+
+### Prior state
+
+`49a1e1ac` (this branch, pre-review) had added the blanket `/.codescout/projects/`. That
+rule would have suppressed the 8 — and silently hidden any future fixture memory. Both
+rules are wrong in opposite directions; neither population is served by a single glob.
+
+## Hypotheses tried
+
+1. **Hypothesis:** the 8 dirs are stale leftovers to delete, not something to ignore.
+   **Test:** each corresponds to a live registered workspace, and activation rewrites
+   them; `.codescout/projects/codescout/memories/` is regenerated for this very repo.
+   **Verdict:** rejected — deleting them is a no-op until the next activation.
+2. **Hypothesis:** they should be tracked like the fixture memories.
+   **Test:** contents are three-line generated stubs naming machine-local absolute roots
+   (`Root: work\Mercury BOM`). They are per-operator, not per-repo.
+   **Verdict:** rejected.
+
+## Fix
+
+Not yet applied — the choice belongs to whoever owns the `6f261da9` stance.
+
+- **Option A (narrow, no policy change):** ignore the eight by name. Honest, zero risk to
+  the fixture files, and stale the moment a ninth workspace is registered.
+- **Option B (structural):** `/.codescout/projects/*/` plus `!` re-includes for the nine
+  fixture projects. Self-maintaining for new workspaces and it keeps future fixture
+  memories visible — but it re-adopts a blanket rule over the tree, which is the thing
+  `6f261da9` argued against, so it needs that author's sign-off.
+- **Option C (root fix, largest):** stop co-locating generated foreign-workspace state
+  with authored fixture memories — write registered-workspace stubs somewhere already
+  ignored. Removes the need for any glob gymnastics.
+
+Whichever lands, the `.gitignore` comment needs its third clause corrected: the tree
+**does** hold untracked generated content on a developer host, and that is exactly why
+the rule is hard to write.
+
+## Tests added
+
+None. A `.gitignore` policy has no unit-test surface, and the failure is environmental —
+invisible in a fresh clone and in CI, which is precisely how the premise got in. Closest
+mechanical guard would be a hygiene check asserting `git status --porcelain
+.codescout/projects` is empty, which only holds on the machines where nothing is wrong.
+
+## Workarounds
+
+Filter it at read time — `git status --porcelain | grep -v '.codescout/projects'` — or
+add the eight to `.git/info/exclude`, which is per-clone and commits nothing.
+
+## Resume
+
+Pick between Options A/B/C above with the author of `6f261da9`, then apply it together
+with the comment correction in `.gitignore` (the `Deliberately NOT` block, lines ~72-79).
+Re-check the untracked set first — `git status --porcelain .codescout/projects` — since
+it grows with every workspace activated since 2026-08-08.
+
+## References
+
+- `6f261da9` — the review-pass commit that set the current rule (finding 5)
+- `49a1e1ac` — the blanket rule it replaced
+- `.gitignore` lines ~72-80
+- PR https://github.com/mareurs/codescout/pull/10

--- a/docs/issues/2026-08-08-gitignore-projects-rule-premise-false-on-a-real-host.md
+++ b/docs/issues/2026-08-08-gitignore-projects-rule-premise-false-on-a-real-host.md
@@ -200,6 +200,23 @@ So the two populations are not "fixtures vs. foreign workspaces". They are "real
 sub-projects" and "directories conjured by an unvalidated id". The second should not exist
 at all, which is why no glob can cleanly describe it.
 
+### Measured 2026-08-08 — both populations reproduce on one host
+
+The mechanism above was inferred when this addendum was first written. It has since been
+reproduced directly, on `experiments` at `9cbe4002`, with no misresolution involved:
+
+- `memory(action="write", topic="…", project_id="zz-definitely-not-a-project")` → `"ok"`,
+  directory count 9 → 10, one new `?? .codescout/projects/zz-definitely-not-a-project/`.
+  **This is the VDI's eight.**
+- `memory(action="read", topic="…", project_id="zz-read-path-probe")` → creates the directory
+  and leaves it **empty**, so the count goes 10 → 11 while `git status` still shows one `??`.
+  **This is this host's two.**
+
+So the difference between the hosts is read-vs-write traffic against a bad `project_id`, not
+configuration and not workspace-root misresolution — the review pass's own first guess, which
+was wrong in the same way the original report was. Tree restored afterwards: count back to 9,
+`git status --porcelain .codescout/projects` empty. Full transcript in the sibling bug file.
+
 ### Two corrections to the report above
 
 - `## Environment` claims the eight are "four repos in the `codescout-ecosystem` umbrella

--- a/docs/issues/2026-08-08-memory-dir-for-project-materializes-any-id.md
+++ b/docs/issues/2026-08-08-memory-dir-for-project-materializes-any-id.md
@@ -1,0 +1,205 @@
+---
+status: open
+opened: 2026-08-08
+closed:
+severity: medium
+owner: marius
+related: []
+tags: [workspace, memory, validation, repo-hygiene]
+kind: bug
+---
+
+# BUG: an unvalidated `project_id` resolves to a fresh per-project memory directory, so any typo or stale id gets its own tree
+
+## Summary
+
+`memory` accepts `project_id` (or its `project` alias) verbatim from tool input and routes
+it through `Workspace::memory_dir_for_project`, which resolves **any** id that is not the
+root project into `<workspace root>/.codescout/projects/<id>/memories`. Nothing checks that
+the id names a real project. A typo, a stale id, or a foreign workspace's name therefore
+gets its own directory under the *active* repo — silently, with no error and no diagnostic.
+
+## Symptom (Effect)
+
+Directories under `.codescout/projects/` whose id is not a subdirectory of the repo. Two on
+this host, both empty, measured 2026-08-08:
+
+```
+$ find /home/marius/work/claude/claude-plugins/.codescout/projects/mcp-server -type f
+$ find /home/marius/work/mirela/eduplanner-site/.codescout/projects/optaplanner -type f
+$ ls -d /home/marius/work/claude/claude-plugins/mcp-server
+ls: cannot access '.../mcp-server': No such file or directory
+$ ls -d /home/marius/work/mirela/eduplanner-site/optaplanner
+ls: cannot access '.../optaplanner': No such file or directory
+```
+
+`optaplanner` is a **sibling** of `eduplanner-site` at `mirela/optaplanner`, not a child.
+
+Empty directories are invisible to `git status`, so on this host the effect is inert. Where
+something also *writes* into them they become permanent `??` entries — the eight reported in
+`docs/issues/2026-08-08-gitignore-projects-rule-premise-false-on-a-real-host.md`.
+
+## Reproduction
+
+Path resolution is confirmed by reading; the directory-creating call site is **not yet
+identified**. Best lead:
+
+```
+memory(action="write", topic="x", project_id="definitely-not-a-project")
+```
+
+on any workspace, then `ls .codescout/projects/`. Predicted result — a
+`definitely-not-a-project/memories/` tree, no error. Run this before working the bug; it is
+one command and it decides whether the write path or a read path does the `mkdir`.
+
+## Environment
+
+Linux, `experiments` at `9cbe4002`, codescout MCP over stdio. Also observed on a Windows VDI
+checkout at `88316ac9` (see the sibling bug file). Not environment-specific — the code path
+has no platform branch.
+
+## Root cause
+
+Two hops, neither of which validates the id.
+
+- `src/tools/memory/mod.rs` — `resolve_memory_dir` reads `project_id`, falling back to the
+  `project` alias, then to `ws.focused`, then to `ROOT_PROJECT_ID`. The input value is passed
+  through as a `String` with no membership check against `ws.projects`.
+- `src/workspace.rs` — `Workspace::memory_dir_for_project` looks the id up in
+  `self.projects`; on miss, `is_root` is `false` via `unwrap_or(false)` and the id lands in
+  the `else` branch, producing `self.root/.codescout/projects/<id>/memories`.
+
+The docstring states this is deliberate:
+
+> An unknown `project_id` is treated as a sub-project (returns a per-project subdirectory
+> under `projects/<id>/`). Previously defaulted to the root memory dir on unknown ID, which
+> silently co-mingled memories from typos or stale IDs with the workspace root's memories —
+> a bug that would go unnoticed until a user noticed crossed-over memories.
+
+That earlier fix was right to stop polluting the root memory store. It replaced one silent
+failure with another: instead of writing a typo's memory into the root, the typo now gets a
+directory of its own. The missing third option — reject the id — was never taken.
+
+**Measured 2026-08-08:** `find` over both phantom paths → zero files (above); `ls -d` over the
+matching repo-relative paths → `No such file or directory`. **Inferred, not measured:** that
+`resolve_memory_dir` is the caller that produced these two specific directories, and which
+call site performs the `mkdir` — `create_dir_all` appears in `src/tools/memory/` only inside
+`tests.rs`, so the creating call lives elsewhere and has not been located.
+
+## Evidence
+
+### The resolution site, `src/workspace.rs`
+
+```rust
+let is_root = self
+    .projects
+    .iter()
+    .find(|p| p.discovered.id == project_id)
+    .map(|p| p.discovered.relative_root == std::path::Path::new("."))
+    .unwrap_or(false);          // <-- unknown id falls through as "not root"
+if is_root {
+    self.root.join(".codescout").join("memories")
+} else {
+    self.root.join(".codescout").join("projects").join(project_id).join("memories")
+}
+```
+
+`find(...)` returning `None` and `find(...)` returning a non-root project are indistinguishable
+downstream. The `unwrap_or(false)` is where "unknown" becomes "sub-project".
+
+### The unvalidated input, `src/tools/memory/mod.rs`
+
+```rust
+let project_param = input
+    .get("project_id")
+    .or_else(|| input.get("project"))
+    .and_then(|v| v.as_str())
+    .map(|s| s.to_string());
+...
+let project_id = project_param
+    .or_else(|| ws.focused.clone())
+    .unwrap_or_else(|| crate::workspace::ROOT_PROJECT_ID.to_string());
+Ok(ws.memory_dir_for_project(&project_id))
+```
+
+Note the `ws.focused` fallback: a stale or foreign value in `focused` routes **every**
+unqualified memory call into a phantom directory, not just calls that name a bad id.
+
+### Cross-host sweep
+
+Nine repos with a `.codescout/projects/` tree, checked across every root registered in
+`~/.config/librarian/workspace.toml`. Two carried phantom ids; both were empty. Full table in
+the review addendum of the sibling bug file.
+
+## Hypotheses tried
+
+1. **Hypothesis:** the phantom dirs are stale leftovers from an older layout, not something
+   still being produced.
+   **Test:** read both call sites; the `unwrap_or(false)` fall-through is present at
+   `9cbe4002`, and `resolve_memory_dir` still passes tool input through unchecked.
+   **Verdict:** rejected as an explanation for the *mechanism* — the code that would produce
+   them is live. Whether these two specific directories are recent or old is undetermined and
+   does not change the fix.
+2. **Hypothesis:** the ids come from foreign-workspace registration rather than from a bad
+   `project_id`.
+   **Test:** `Workspace::memory_dir_for_project` derives the path from `self.root`, so a
+   foreign workspace's own state cannot land under another repo's root. `optaplanner` is a
+   sibling directory name, and `mcp-server` matches no directory at all.
+   **Verdict:** rejected — the path is anchored to the active workspace, so the id had to
+   arrive as an argument.
+
+## Fix
+
+Not yet applied. Plan:
+
+1. Distinguish the two cases in `Workspace::memory_dir_for_project` — a lookup miss is not a
+   sub-project. Either return `Option<PathBuf>`/`Result` and let callers decide, or keep the
+   signature and add a sibling `resolve_project_id` that callers must go through first.
+2. In `resolve_memory_dir`, reject an unknown `project_id` with a `RecoverableError` listing
+   the workspace's real project ids — the guidance case in `get_guide("error-handling")`: a
+   deterministic input mistake the agent can correct on the retry. Do **not** auto-guess a
+   nearest match on a write path.
+3. Validate the `ws.focused` fallback the same way, and clear `focused` when it names a
+   project that no longer exists.
+4. Sweep the existing phantoms after the fix lands: they are safe to delete once nothing
+   recreates them.
+
+## Tests added
+
+None yet. Three are wanted, and all three are cheap because the resolution is pure:
+
+- `memory_dir_for_project` distinguishes an unknown id from a known non-root project — the
+  discriminating case the current `unwrap_or(false)` collapses.
+- A `memory(action="write", project_id="<unknown>")` call returns a `RecoverableError` naming
+  the valid ids, and creates no directory.
+- A stale `ws.focused` does not route writes into a phantom directory.
+
+The first is the one that matters: a mutation flipping `unwrap_or(false)` to `unwrap_or(true)`
+would change behavior in the opposite direction and no current test would notice.
+
+## Workarounds
+
+Always pass a `project_id` that appears in `project_status`, or omit it entirely and let it
+fall back to the root project. Delete stray directories with
+`rmdir .codescout/projects/<id>/memories .codescout/projects/<id>` — they will be recreated if
+the bad id is used again.
+
+## Resume
+
+Run the one-command reproduction above (`memory(action="write", topic="x",
+project_id="definitely-not-a-project")` then `ls .codescout/projects/`) to identify the
+`mkdir` call site. Then implement fix step 1 in `src/workspace.rs` and step 2 in
+`src/tools/memory/mod.rs`, with the three tests above. The `.gitignore` half of this is
+tracked separately in
+`docs/issues/2026-08-08-gitignore-projects-rule-premise-false-on-a-real-host.md` — do not
+close that one on this fix alone, or vice versa.
+
+## References
+
+- `src/workspace.rs` — `Workspace::memory_dir_for_project`, the `unwrap_or(false)` site
+- `src/tools/memory/mod.rs` — `resolve_memory_dir`, the unvalidated input site
+- `src/agent/mod.rs` — the other caller; passes `p.discovered.id`, so always valid
+- `docs/issues/2026-08-08-gitignore-projects-rule-premise-false-on-a-real-host.md` — the
+  symptom this bug produces on a host where something writes into the phantom directories
+- `get_guide("error-handling")` — `RecoverableError` vs `anyhow::bail!` for fix step 2
+- PR https://github.com/mareurs/codescout/pull/11

--- a/docs/issues/2026-08-08-memory-dir-for-project-materializes-any-id.md
+++ b/docs/issues/2026-08-08-memory-dir-for-project-materializes-any-id.md
@@ -13,45 +13,87 @@ kind: bug
 
 ## Summary
 
-`memory` accepts `project_id` (or its `project` alias) verbatim from tool input and routes
-it through `Workspace::memory_dir_for_project`, which resolves **any** id that is not the
-root project into `<workspace root>/.codescout/projects/<id>/memories`. Nothing checks that
-the id names a real project. A typo, a stale id, or a foreign workspace's name therefore
-gets its own directory under the *active* repo — silently, with no error and no diagnostic.
+`memory` accepts `project_id` (or its `project` alias) verbatim from tool input and routes it
+through `Workspace::memory_dir_for_project`, which resolves **any** id that is not the root
+project into `<workspace root>/.codescout/projects/<id>/memories`. Nothing checks that the id
+names a real project.
 
+Two consequences, both reproduced on demand. A **write** with a bad id succeeds silently and
+leaves an untracked directory in the repo. A **read** with a bad id creates an empty directory
+and answers *"no memory topics exist yet"* with `available_topics: []` — telling the caller the
+project has no memories when the truth is that the project does not exist. The misleading read
+is the worse of the two: litter is noise, but a confident empty answer is acted on.
 ## Symptom (Effect)
 
-Directories under `.codescout/projects/` whose id is not a subdirectory of the repo. Two on
-this host, both empty, measured 2026-08-08:
+Three effects, all reproduced on demand 2026-08-08 (see Reproduction). Ranked by how badly
+they mislead.
+
+**1 — A read against a non-existent project reports that the project has no memories.**
 
 ```
-$ find /home/marius/work/claude/claude-plugins/.codescout/projects/mcp-server -type f
-$ find /home/marius/work/mirela/eduplanner-site/.codescout/projects/optaplanner -type f
-$ ls -d /home/marius/work/claude/claude-plugins/mcp-server
-ls: cannot access '.../mcp-server': No such file or directory
-$ ls -d /home/marius/work/mirela/eduplanner-site/optaplanner
-ls: cannot access '.../optaplanner': No such file or directory
+memory(action="read", topic="nonexistent-topic", project_id="zz-read-path-probe")
+→ { "ok": false,
+    "error": "topic 'nonexistent-topic' not found",
+    "hint": "no memory topics exist yet — create one with memory(action='write', …)",
+    "available_topics": [] }
 ```
 
-`optaplanner` is a **sibling** of `eduplanner-site` at `mirela/optaplanner`, not a child.
+`zz-read-path-probe` is not a project. The correct answer is "no such project"; the answer
+given is "this project has no memories yet", which an agent will act on. `available_topics`
+being `[]` reads as authoritative emptiness.
 
-Empty directories are invisible to `git status`, so on this host the effect is inert. Where
-something also *writes* into them they become permanent `??` entries — the eight reported in
-`docs/issues/2026-08-08-gitignore-projects-rule-premise-false-on-a-real-host.md`.
+**2 — A write against a non-existent project succeeds silently and litters the repo.**
 
+```
+memory(action="write", topic="zz-probe-delete-me", project_id="zz-definitely-not-a-project", content="…")
+→ "ok"
+```
+
+```
+$ ls -1 .codescout/projects | wc -l      # 9 before, 10 after
+$ find .codescout/projects/zz-definitely-not-a-project -type f
+.codescout/projects/zz-definitely-not-a-project/memories/zz-probe-delete-me.md
+$ git status --porcelain .codescout/projects
+?? .codescout/projects/zz-definitely-not-a-project/
+```
+
+**3 — Both paths create the directory; only the write path makes it visible to git.** The
+read probe created `.codescout/projects/zz-read-path-probe/` and left it empty, so the
+directory count went 10 → 11 while `git status` still reported exactly one `??` entry. Git
+cannot see an empty directory.
+
+That asymmetry explains both observed populations without any host difference:
+
+| origin | on disk | `git status` | observed as |
+|---|---|---|---|
+| read with a bad id | empty dir | invisible | the two phantoms on this host — `claude-plugins/…/mcp-server`, `eduplanner-site/…/optaplanner` |
+| write with a bad id | dir + file | `??` | the eight on the VDI |
 ## Reproduction
 
-Path resolution is confirmed by reading; the directory-creating call site is **not yet
-identified**. Best lead:
+Fully reproducible. Two calls, on any workspace, no fixture setup. Measured 2026-08-08 on
+`experiments` at `9cbe4002`, codescout MCP over stdio:
 
 ```
-memory(action="write", topic="x", project_id="definitely-not-a-project")
+# 1 — write path: silent success, visible litter
+memory(action="write", topic="zz-probe-delete-me",
+       project_id="zz-definitely-not-a-project",
+       content="probe")
+ls -1 .codescout/projects | wc -l          # 9 → 10
+git status --porcelain .codescout/projects # ?? .codescout/projects/zz-definitely-not-a-project/
+
+# 2 — read path: misleading answer, invisible litter
+memory(action="read", topic="nonexistent-topic", project_id="zz-read-path-probe")
+ls -d .codescout/projects/zz-read-path-probe   # exists, empty
+ls -1 .codescout/projects | wc -l              # 10 → 11
+git status --porcelain .codescout/projects      # still ONE ?? entry
 ```
 
-on any workspace, then `ls .codescout/projects/`. Predicted result — a
-`definitely-not-a-project/memories/` tree, no error. Run this before working the bug; it is
-one command and it decides whether the write path or a read path does the `mkdir`.
+Cleanup: `rm -rf .codescout/projects/zz-definitely-not-a-project
+.codescout/projects/zz-read-path-probe`, then confirm the count returns to 9 and the status
+is empty.
 
+The `project` alias reaches the same code path (`resolve_memory_dir` reads `project_id` then
+falls back to `project`), so both spellings reproduce it.
 ## Environment
 
 Linux, `experiments` at `9cbe4002`, codescout MCP over stdio. Also observed on a Windows VDI
@@ -69,6 +111,9 @@ Two hops, neither of which validates the id.
   `self.projects`; on miss, `is_root` is `false` via `unwrap_or(false)` and the id lands in
   the `else` branch, producing `self.root/.codescout/projects/<id>/memories`.
 
+`find(...) == None` and `find(...) == Some(non-root project)` are indistinguishable
+downstream. The `unwrap_or(false)` is exactly where "unknown" silently becomes "sub-project".
+
 The docstring states this is deliberate:
 
 > An unknown `project_id` is treated as a sub-project (returns a per-project subdirectory
@@ -77,15 +122,20 @@ The docstring states this is deliberate:
 > a bug that would go unnoticed until a user noticed crossed-over memories.
 
 That earlier fix was right to stop polluting the root memory store. It replaced one silent
-failure with another: instead of writing a typo's memory into the root, the typo now gets a
-directory of its own. The missing third option — reject the id — was never taken.
+failure with two: the typo now gets a directory of its own, and a *read* against the typo
+reports the project as empty rather than absent. The missing third option — reject the id —
+was never taken.
 
-**Measured 2026-08-08:** `find` over both phantom paths → zero files (above); `ls -d` over the
-matching repo-relative paths → `No such file or directory`. **Inferred, not measured:** that
-`resolve_memory_dir` is the caller that produced these two specific directories, and which
-call site performs the `mkdir` — `create_dir_all` appears in `src/tools/memory/` only inside
-`tests.rs`, so the creating call lives elsewhere and has not been located.
+**Measured 2026-08-08** (`experiments` @ `9cbe4002`, full transcript under Reproduction):
+`memory(write, project_id="zz-definitely-not-a-project")` → `"ok"`, directory count 9 → 10,
+one new `??` entry; `memory(read, project_id="zz-read-path-probe")` → `available_topics: []`,
+directory count 10 → 11, still one `??` entry. Both directories were created by the calls; the
+read-created one is empty, which is why it is invisible to git.
 
+**Still inferred, not measured:** which function performs the `mkdir`. `create_dir_all` appears
+in `src/tools/memory/` only inside `tests.rs`, so the creating call is elsewhere and has not
+been located — but it is now known to be on a path both `read` and `write` traverse, which
+narrows it to the shared resolve/ensure step rather than the write handler.
 ## Evidence
 
 ### The resolution site, `src/workspace.rs`
@@ -135,19 +185,31 @@ the review addendum of the sibling bug file.
 
 1. **Hypothesis:** the phantom dirs are stale leftovers from an older layout, not something
    still being produced.
-   **Test:** read both call sites; the `unwrap_or(false)` fall-through is present at
-   `9cbe4002`, and `resolve_memory_dir` still passes tool input through unchecked.
-   **Verdict:** rejected as an explanation for the *mechanism* — the code that would produce
-   them is live. Whether these two specific directories are recent or old is undetermined and
-   does not change the fix.
+   **Test:** ran the two-call reproduction on `9cbe4002`.
+   **Verdict:** **rejected — confirmed live.** Both calls created a directory that did not
+   exist a second earlier.
 2. **Hypothesis:** the ids come from foreign-workspace registration rather than from a bad
    `project_id`.
    **Test:** `Workspace::memory_dir_for_project` derives the path from `self.root`, so a
    foreign workspace's own state cannot land under another repo's root. `optaplanner` is a
-   sibling directory name, and `mcp-server` matches no directory at all.
-   **Verdict:** rejected — the path is anchored to the active workspace, so the id had to
-   arrive as an argument.
-
+   sibling directory name and `mcp-server` matches no directory at all. Then reproduced the
+   exact shape with an explicit bad `project_id`.
+   **Verdict:** rejected — the path is anchored to the active workspace, and the id arrives as
+   an argument.
+3. **Hypothesis:** only the write path creates the directory, so read-only use is safe.
+   **Test:** `memory(action="read", topic="nonexistent-topic", project_id="zz-read-path-probe")`
+   on a clean tree.
+   **Verdict:** **rejected.** The read created the directory too. It is empty, which is the
+   entire reason this host's two phantoms were invisible to `git status` while the VDI's eight
+   were not — so the population difference between the two hosts is read-vs-write traffic, not
+   configuration.
+4. **Hypothesis:** the two hosts differ because of workspace-root misresolution on the VDI.
+   **Test:** superseded by 3 — a plain bad `project_id` reproduces both populations on one
+   host, with no misresolution involved.
+   **Verdict:** withdrawn. This was the review pass's own first guess, and it was wrong in the
+   same way the original report was: a plausible mechanism adopted before the cheap experiment
+   was run. The VDI `project_status` check is still worth doing, but it is no longer load-bearing
+   for this bug.
 ## Fix
 
 Not yet applied. Plan:
@@ -166,17 +228,23 @@ Not yet applied. Plan:
 
 ## Tests added
 
-None yet. Three are wanted, and all three are cheap because the resolution is pure:
+None yet. Four are wanted, and all four are cheap because the resolution is pure:
 
-- `memory_dir_for_project` distinguishes an unknown id from a known non-root project — the
-  discriminating case the current `unwrap_or(false)` collapses.
-- A `memory(action="write", project_id="<unknown>")` call returns a `RecoverableError` naming
-  the valid ids, and creates no directory.
-- A stale `ws.focused` does not route writes into a phantom directory.
+1. **`memory_dir_for_project` distinguishes an unknown id from a known non-root project.** The
+   discriminating case the current `unwrap_or(false)` collapses. This is the one that matters:
+   a mutation flipping `unwrap_or(false)` to `unwrap_or(true)` changes behaviour in the opposite
+   direction, and no test in the suite today would notice either mutation.
+2. **`memory(write, project_id=<unknown>)` returns a `RecoverableError` naming the valid ids,
+   and creates no directory.** Assert on the absence of the directory, not just the error — the
+   litter and the error are separate failures and a fix could address only one.
+3. **`memory(read, project_id=<unknown>)` says "no such project", not "no topics".** Assert the
+   error text distinguishes the two, since `available_topics: []` is what makes the current
+   answer actionable and wrong.
+4. **A stale `ws.focused` does not route writes into a phantom directory.**
 
-The first is the one that matters: a mutation flipping `unwrap_or(false)` to `unwrap_or(true)`
-would change behavior in the opposite direction and no current test would notice.
-
+Note for whoever writes 2 and 3: assert on a tree that is clean *before* the call and checked
+*after*, in that order. A fixture that only checks the return value passes even if the directory
+is still created — which is precisely how this shipped.
 ## Workarounds
 
 Always pass a `project_id` that appears in `project_status`, or omit it entirely and let it
@@ -186,14 +254,29 @@ the bad id is used again.
 
 ## Resume
 
-Run the one-command reproduction above (`memory(action="write", topic="x",
-project_id="definitely-not-a-project")` then `ls .codescout/projects/`) to identify the
-`mkdir` call site. Then implement fix step 1 in `src/workspace.rs` and step 2 in
-`src/tools/memory/mod.rs`, with the three tests above. The `.gitignore` half of this is
-tracked separately in
-`docs/issues/2026-08-08-gitignore-projects-rule-premise-false-on-a-real-host.md` — do not
-close that one on this fix alone, or vice versa.
+Reproduction is done — do not re-run it to "confirm"; the transcript is above and the tree was
+cleaned afterwards (count back to 9, status empty).
 
+Next concrete action: locate the `mkdir`. It is on a path both `read` and `write` traverse, so
+grep `create_dir_all` across `src/` (not just `src/tools/memory/`, where it appears only in
+`tests.rs`) and check the shared resolve/ensure step that `resolve_memory_dir` feeds. Then:
+
+1. `src/workspace.rs` — make a lookup miss distinguishable from a non-root hit. Either return
+   `Option<PathBuf>`/`Result`, or add a sibling `resolve_project_id` that callers must pass
+   through first.
+2. `src/tools/memory/mod.rs` — `resolve_memory_dir` rejects an unknown id with a
+   `RecoverableError` listing the workspace's real project ids. This is the guidance case in
+   `get_guide("error-handling")`: a deterministic input mistake the agent corrects on retry. Do
+   **not** auto-guess a nearest match on a write path.
+3. Same treatment for the `ws.focused` fallback, and clear `focused` when it names a project that
+   no longer exists.
+4. Add the four tests under Tests added, 1 and 3 first.
+5. Sweep the two existing phantoms (`claude-plugins/.codescout/projects/mcp-server/`,
+   `mirela/eduplanner-site/.codescout/projects/optaplanner/`) once nothing recreates them.
+
+The `.gitignore` half is tracked separately in
+`docs/issues/2026-08-08-gitignore-projects-rule-premise-false-on-a-real-host.md`. Do not close
+either one on the other's fix.
 ## References
 
 - `src/workspace.rs` — `Workspace::memory_dir_for_project`, the `unwrap_or(false)` site


### PR DESCRIPTION
@
One bug file. No code changes.

## What this reports

`6f261da9` (review pass on #10) dropped the blanket `/.codescout/projects/` ignore rule and left a comment explaining why. Two of its three clauses are correct and load-bearing: 53 tracked, hand-authored fixture memory files live under that tree, and ignoring it would not untrack them but would hide every future one from `git status` with no error. Nothing here disputes that.

The third clause does not hold: *"it shadows no cache, since that path has no untracked content at all"*. True of a fresh clone and of CI. False on any host that has activated a workspace outside this repo — which is the normal state for the cross-project flows CLAUDE.md documents. On the authoring machine there are eight such directories, so `git status` now carries eight permanent `??` entries.

## The actual finding

Two populations share one directory, and each candidate rule serves only one of them.

- **Tracked — 53 files, 9 projects:** `codescout-embed`, `edit-eval-rust`, `java-library`, `kotlin-library`, `librarian-mcp`, `nav-eval-rust`, `python-library`, `rust-library`, `typescript-library`. All in-repo fixtures, hand-authored, maintained by `chore(memories):` commits.
- **Untracked — 8 dirs:** the operator registered foreign workspaces. Machine-generated activation stubs. `.codescout/projects/Mercury BOM/memories/onboarding.md` is 100 bytes, entire contents `Languages: … / Root: work\Mercury BOM / Manifest: requirements.txt`, written 2026-07-13 and regenerable.

The blanket rule this branch originally shipped (`49a1e1ac`) suppressed the 8 but would have silently hidden future fixture memories. The narrow rule that replaced it protects the fixtures but leaves the 8 permanently in `git status`. Both are wrong in opposite directions, because the tree has no naming or structural boundary between authored and generated content — so no single glob expresses the intent. The false clause is a symptom of that, not carelessness: it was checked against the only environments where the question looks settled.

## Filed, not fixed

Three options are written up, and choosing among them revisits a stance `6f261da9` took deliberately, so it wants that author sign-off rather than a drive-by fix:

- **A, narrow:** ignore the eight by name. Zero risk to the fixtures, stale the moment a ninth workspace is registered.
- **B, structural:** `/.codescout/projects/*/` plus `!` re-includes for the nine fixture projects. Self-maintaining, keeps future fixture memories visible — but re-adopts a blanket rule over the tree, which is what `6f261da9` argued against.
- **C, root:** stop co-locating generated foreign-workspace state with authored fixture memories; write activation stubs somewhere already ignored. Removes the need for glob gymnastics entirely.

Whichever lands, the comment third clause needs correcting.

Severity `low`, status `open`. The cost of not fixing it today is eight noisy `git status` lines, not lost data.

`Tests added` says none, with the reason stated: a `.gitignore` policy has no unit-test surface, and the closest mechanical guard — asserting `git status --porcelain .codescout/projects` is empty — holds precisely on the machines where nothing is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@