### PR TITLE
fix: 6 Windows-only bugs found by the first native test run on this VDI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,13 @@ tests/fixtures/*/.codescout/
 /.codescout/code-index.db
 /target-release-new/
 /.vscode/
+
+# Locally downloaded ONNX runtime shared library (windows-gnu / EDR workaround
+# for the local-embed-dynamic feature). Fetched per-machine, never committed.
+/.onnxruntime/
+
+# Stray artifact from an accidental `> nul`/`2>nul` redirect under Git Bash on
+# Windows (cmd.exe NUL-device syntax creates a literal file when run under
+# bash instead of discarding output). Recurs across sessions; harmless to
+# delete, never intentional.
+/nul

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,10 @@ windows-sys = { version = "0.61", features = [
     # `bash -c`) running, which is how a cancelled run_command kept going.
     "Win32_System_JobObjects",
     "Win32_System_Threading",
+    # ToolHelp snapshot walk: Windows has no getppid(), so parent_pid() (used
+    # by the rendezvous hook match) finds this process's PROCESSENTRY32W entry
+    # in a full-system snapshot and reads th32ParentProcessID off it.
+    "Win32_System_Diagnostics_ToolHelp",
 ] }
 
 [features]

--- a/docs/issues/2026-08-19-artifact-create-abs-path-missing-forward-slash-normalization.md
+++ b/docs/issues/2026-08-19-artifact-create-abs-path-missing-forward-slash-normalization.md
@@ -1,0 +1,131 @@
+---
+status: open
+opened: 2026-08-19
+closed:
+severity: medium
+owner: marius
+related: []
+tags: [windows, librarian, artifact, guide-routing]
+kind: bug
+---
+
+# BUG: `artifact(action="create")` emits `abs_path` via raw `PathBuf::display()`, breaking Windows tracker-guide routing
+
+## Summary
+`src/librarian/tools/create.rs:368` builds the create-response's `abs_path`
+field with a raw `PathBuf::display().to_string()` instead of the project's
+`to_forward_slash` helper, which every sibling librarian tool (`mv.rs`,
+`context.rs`, `doctor.rs`, `get.rs`, `reindex.rs`, `util.rs`) uses. On
+Windows this leaves backslashes in the path, which breaks
+`names_tracker_path`'s forward-slash-only `"docs/trackers/"` substring
+match — so creating a tracker artifact never routes to the
+`tracker-conventions` guide hint on Windows.
+
+## Symptom (Effect)
+```
+thread 'server::guide_hint_tests::an_artifact_call_naming_a_tracker_path_delivers_the_tracker_guide' panicked at src\server.rs:4600:
+expected hint to contain "tracker-conventions", got "...topic 'librarian'..."
+```
+
+## Reproduction
+1. `git checkout experiments` at `5b54848fd2a4e7fe5da6bf277dc85de39958ff27`
+2. `cargo +1.97.1-x86_64-pc-windows-gnu test --release --features server-stack --lib server::guide_hint_tests::an_artifact_call_naming_a_tracker_path_delivers_the_tracker_guide -- --nocapture`
+3. Observe the panic above.
+
+## Environment
+Windows 11 Enterprise 10.0.26200 (VDI), `1.97.1-x86_64-pc-windows-gnu`
+toolchain (host toolchain forced to gnu — this VDI has no MSVC C++ Build
+Tools; see `docs/issues/archive/2026-08-08-cyberark-epm-blocks-ort-sys-build-script.md`).
+`codescout` repo, `experiments` branch.
+
+## Root cause
+`src/librarian/tools/create.rs:368`:
+```rust
+"abs_path": row.abs_path.display().to_string(),
+```
+— a raw `PathBuf::display()`, never passed through
+`crate::util::fs::to_forward_slash`. Confirmed via grep that `create.rs` is
+the one librarian tool missing from the `to_forward_slash` call-site list;
+every sibling tool that emits path fields calls it.
+
+Downstream, `names_tracker_path` (`src/librarian/adapter.rs:276-292`)
+checks `abs_path`/`rel_path` for the literal substring `"docs/trackers/"`
+(forward-slash). Its own unit test passes fine (hand-written forward-slash
+strings), so the discriminator logic itself is correct — the break is
+purely in `create.rs`'s un-normalized path emission feeding it a
+backslash-separated string that can never contain that substring on
+Windows. `LibrarianAdapter::relevant_guide_topic`
+(`src/librarian/adapter.rs:182-205`) then falls through to the default
+`"librarian"` guide instead of `"tracker-conventions"`.
+
+This is Windows-only: on Unix, `PathBuf::display()` is naturally
+forward-slash, so the missing normalization is invisible there.
+
+The guide-routing feature (`names_tracker_path`) was wired in commit
+`73ccb495` ("feat(prompts): wire the three guides you chose, and route by
+what the call touched"), part of the experiments fast-forward — this is a
+genuine regression in freshly-merged code, not a stale test expectation;
+the test matches the feature's documented intent (see
+`docs/issues/archive/2026-08-16-cap-evicted-guidance-lands-in-guides-nothing-triggers.md`,
+cited in both the test and `names_tracker_path`'s own doc comment).
+
+*Inferred from source comparison (create.rs vs sibling tools) and the
+passing-synthetic-vs-failing-integration test split — not independently
+re-verified at runtime with a standalone probe binary: this sandbox's
+CyberArk EPM policy blocks execution of any freshly-compiled binary,
+including a minimal isolated repro (see
+`docs/issues/archive/2026-08-08-cyberark-epm-blocks-ort-sys-build-script.md`,
+which the 2026-08-19 investigation suggests may be a general fresh-binary
+execution block rather than ort-sys-specific — worth a follow-up if this
+resurfaces elsewhere).*
+
+## Evidence
+### Subagent investigation (2026-08-19)
+```
+grep for to_forward_slash call sites across src/librarian/tools/*.rs:
+mv.rs, context.rs, doctor.rs, get.rs, reindex.rs, util.rs — all present.
+create.rs — absent.
+```
+
+## Hypotheses tried
+1. **Hypothesis:** `names_tracker_path`'s own matching logic is broken.
+   **Test:** Read `names_tracker_path` (adapter.rs:276-292) and its
+   existing unit test (adapter.rs:766-795, forward-slash literals).
+   **Verdict:** rejected — the discriminator's own test passes; the logic
+   itself is correct given a forward-slash input.
+2. **Hypothesis:** `create.rs`'s `abs_path` field is un-normalized on
+   Windows, so the input `names_tracker_path` receives never contains the
+   substring it looks for.
+   **Test:** Compared `create.rs:368` against every sibling librarian
+   tool's path-emission call sites.
+   **Verdict:** confirmed — `create.rs` is the sole outlier missing
+   `to_forward_slash`.
+
+## Fix
+Not yet implemented. Change `src/librarian/tools/create.rs:368` from
+`row.abs_path.display().to_string()` to go through
+`crate::util::fs::to_forward_slash`, matching every sibling tool.
+
+## Tests added
+N/A — not yet fixed. The existing test
+(`src/server.rs`, `guide_hint_tests::an_artifact_call_naming_a_tracker_path_delivers_the_tracker_guide`)
+already covers this once corrected.
+
+## Workarounds
+None; on Windows, creating a tracker artifact does not surface the
+`tracker-conventions` guide hint. The artifact itself is created correctly
+— only the guide-routing hint is affected.
+
+## Resume
+Apply `to_forward_slash` at `src/librarian/tools/create.rs:368`, matching
+the pattern in `mv.rs`/`context.rs`/`doctor.rs`/`get.rs`/`reindex.rs`/`util.rs`.
+Re-run the cited test to confirm. Also worth checking whether other
+recently-added `create.rs` response fields have the same gap.
+
+## References
+- `src/librarian/tools/create.rs:368` (the missing normalization)
+- `src/librarian/adapter.rs:182-205` (`relevant_guide_topic`)
+- `src/librarian/adapter.rs:276-292` (`names_tracker_path`)
+- `src/server.rs:4600` (the failing test)
+- commit `73ccb495` ("feat(prompts): wire the three guides you chose, and route by what the call touched")
+- `docs/issues/archive/2026-08-16-cap-evicted-guidance-lands-in-guides-nothing-triggers.md`

--- a/docs/issues/2026-08-19-artifact-create-abs-path-missing-forward-slash-normalization.md
+++ b/docs/issues/2026-08-19-artifact-create-abs-path-missing-forward-slash-normalization.md
@@ -1,7 +1,7 @@
 ---
-status: open
+status: fixed
 opened: 2026-08-19
-closed:
+closed: 2026-08-19
 severity: medium
 owner: marius
 related: []
@@ -102,14 +102,48 @@ create.rs — absent.
    `to_forward_slash`.
 
 ## Fix
-Not yet implemented. Change `src/librarian/tools/create.rs:368` from
-`row.abs_path.display().to_string()` to go through
-`crate::util::fs::to_forward_slash`, matching every sibling tool.
+
+Applied at `src/librarian/tools/create.rs:368` (function `call`), `experiments` branch, commit `66ed27dea7f48557ddfa25886527f5d6c1a7ccaa` (fast-forward to `master` per this repo's CLAUDE.md — no separate master SHA to record).
+
+Before:
+```rust
+let mut result = json!({"id": id, "abs_path": row.abs_path.display().to_string()});
+```
+
+After:
+```rust
+let mut result =
+    json!({"id": id, "abs_path": crate::util::fs::to_forward_slash(&row.abs_path)});
+```
+
+This matches the pattern already used by every sibling librarian tool (`mv.rs`, `context.rs`, `doctor.rs`, `get.rs`, `reindex.rs`, `util.rs`). Checked the rest of `call()`'s response-construction block for other un-normalized path fields — `abs_path` was the only path field emitted in that function's JSON response, so no other gap was found nearby.
 
 ## Tests added
-N/A — not yet fixed. The existing test
+
+No new test — the existing test
 (`src/server.rs`, `guide_hint_tests::an_artifact_call_naming_a_tracker_path_delivers_the_tracker_guide`)
-already covers this once corrected.
+already covered this. Confirmed green after the fix:
+
+**Follow-up correction (2026-08-19):** the `to_forward_slash` fix also flipped
+`abs_path` from native-separator to forward-slash on Windows for every
+caller, which broke two OTHER pre-existing tests in the same file that
+hardcoded the old native-separator expectation:
+`librarian::tools::create::tests::creates_with_inferred_repo` (a
+`starts_with` check against a raw, non-normalized `TempDir` path) and
+`creates_with_subdir_prepend` (an `assert_eq!` against
+`PathBuf::join(...).to_string_lossy()`, also native-separator). Both fixed
+by normalizing the test's expected/comparison value through the same
+`crate::util::fs::to_forward_slash` helper. All 23 tests in
+`librarian::tools::create::tests` pass:
+```
+test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 4010 filtered out; finished in 0.18s
+```
+
+```
+test server::guide_hint_tests::an_artifact_call_naming_a_tracker_path_delivers_the_tracker_guide ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4032 filtered out; finished in 0.52s
+```
 
 ## Workarounds
 None; on Windows, creating a tracker artifact does not surface the
@@ -117,11 +151,7 @@ None; on Windows, creating a tracker artifact does not surface the
 — only the guide-routing hint is affected.
 
 ## Resume
-Apply `to_forward_slash` at `src/librarian/tools/create.rs:368`, matching
-the pattern in `mv.rs`/`context.rs`/`doctor.rs`/`get.rs`/`reindex.rs`/`util.rs`.
-Re-run the cited test to confirm. Also worth checking whether other
-recently-added `create.rs` response fields have the same gap.
-
+Fixed. N/A.
 ## References
 - `src/librarian/tools/create.rs:368` (the missing normalization)
 - `src/librarian/adapter.rs:182-205` (`relevant_guide_topic`)

--- a/docs/issues/2026-08-19-doctor-outside-roots-group-rewrites-posix-paths-with-backslashes.md
+++ b/docs/issues/2026-08-19-doctor-outside-roots-group-rewrites-posix-paths-with-backslashes.md
@@ -1,7 +1,7 @@
 ---
-status: open
+status: fixed
 opened: 2026-08-19
-closed:
+closed: 2026-08-19
 severity: low
 owner: marius
 related: []
@@ -84,6 +84,65 @@ the outside-roots sample stable and its remainder reachable", 2026-08-14) —
 part of the experiments fast-forward, never previously exercised on a
 Windows host/toolchain.
 
+## Fix
+
+`outside_roots_group` (`src/librarian/tools/doctor.rs:831-843`, now 831-847)
+rewritten to do string-only prefix extraction — `path.split('/')` plus a
+`Vec<&str>`/`.join("/")` rebuild, with no `std::path::Path`/`PathBuf`
+anywhere in the function. Same idea as `to_forward_slash` (`src/util/fs.rs`)
+but string-native from the start, since `to_forward_slash` itself takes a
+`&Path` and would have re-introduced the exact same separator hazard.
+
+Before:
+```rust
+fn outside_roots_group(path: &str) -> String {
+    let p = std::path::Path::new(path);
+    let mut prefix = std::path::PathBuf::new();
+    for comp in p.components() {
+        if comp.as_os_str() == "docs" {
+            return prefix.to_string_lossy().into_owned();
+        }
+        prefix.push(comp);
+    }
+    p.parent()
+        .map(|d| d.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.to_string())
+}
+```
+
+After:
+```rust
+fn outside_roots_group(path: &str) -> String {
+    let mut segments: Vec<&str> = path.split('/').collect();
+    if let Some(docs_idx) = segments.iter().position(|s| *s == "docs") {
+        return segments[..docs_idx].join("/");
+    }
+    if segments.len() > 1 {
+        segments.pop();
+        let joined = segments.join("/");
+        if joined.is_empty() && path.starts_with('/') {
+            "/".to_string()
+        } else {
+            joined
+        }
+    } else {
+        String::new()
+    }
+}
+```
+
+Verified on Windows (`1.97.1-x86_64-pc-windows-gnu`):
+```
+test librarian::tools::doctor::tests::outside_roots_group_uses_the_project_prefix_before_docs ... ok
+test librarian::tools::doctor::tests::outside_roots_group_falls_back_to_the_parent_without_a_docs_component ... ok
+test librarian::tools::doctor::tests::outside_roots_by_project_counts_elided_rows_too ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 4030 filtered out; finished in 0.11s
+```
+`cargo fmt` run on the file — no further changes.
+
+Fixed on `experiments`, base commit `66ed27dea7f48557ddfa25886527f5d6c1a7ccaa`
+(fast-forward branch — no separate master SHA needed).
 ## Hypotheses tried
 1. **Hypothesis:** Windows `PathBuf` round-tripping silently normalizes
    separators, breaking a function contractually meant to stay POSIX-style.
@@ -92,16 +151,10 @@ Windows host/toolchain.
    **Verdict:** confirmed.
    **Evidence link:** Root cause section above.
 
-## Fix
-Not yet implemented. `outside_roots_group` should operate on the path as a
-plain string (split on `/` directly, or normalize with the project's
-existing `to_forward_slash` helper — see `src/util/fs.rs`) instead of
-routing through `std::path::Path`/`PathBuf`, since the function's own
-contract says it isn't doing real filesystem-path work.
-
 ## Tests added
-N/A — not yet fixed. The two existing tests (`doctor.rs:2482-2508`,
-`doctor.rs:2540-2551`) already cover this once corrected.
+The two existing tests (`doctor.rs:2482-2508`, `doctor.rs:2540-2551`)
+already covered this once corrected — no new tests were needed; see
+`## Fix` below for the confirming test run.
 
 ## Workarounds
 None needed for correctness on POSIX hosts (the bug is Windows-only); on
@@ -109,11 +162,8 @@ Windows, the "outside roots" doctor report's grouping/counts are unreliable
 until fixed.
 
 ## Resume
-Rewrite `outside_roots_group` (`src/librarian/tools/doctor.rs:831-843`) to
-do string-only prefix extraction (no `std::path::Path`/`PathBuf`), matching
-the pattern the project's `to_forward_slash` helper already uses elsewhere.
-Re-run the two cited tests to confirm.
 
+Fixed. N/A.
 ## References
 - `src/librarian/tools/doctor.rs:831-843` (`outside_roots_group`)
 - `src/librarian/tools/doctor.rs:264` (map-key call site)

--- a/docs/issues/2026-08-19-doctor-outside-roots-group-rewrites-posix-paths-with-backslashes.md
+++ b/docs/issues/2026-08-19-doctor-outside-roots-group-rewrites-posix-paths-with-backslashes.md
@@ -1,0 +1,122 @@
+---
+status: open
+opened: 2026-08-19
+closed:
+severity: low
+owner: marius
+related: []
+tags: [windows, librarian, doctor, path-handling]
+kind: bug
+---
+
+# BUG: `outside_roots_group()` silently rewrites POSIX-style artifact paths with backslashes on Windows, breaking both its display string and a map-key lookup
+
+## Summary
+`src/librarian/tools/doctor.rs`'s `outside_roots_group()` builds its return
+value with `std::path::PathBuf`, which renders with native `\` separators on
+Windows regardless of the input's separators. Artifact paths are always
+POSIX-style strings by contract, so on Windows this function silently
+corrupts the "reporting key" it's documented to produce — both directly (the
+displayed group string) and indirectly (a map keyed by the same function's
+output no longer matches a POSIX-style lookup key). Same defect class as the
+already-fixed bug `c8902da802c0117d` (symbols glob overview `Path::display()`
+on Windows).
+
+## Symptom (Effect)
+```
+# outside_roots_group_uses_the_project_prefix_before_docs
+left:  "\home\u\work\proj"
+right: "/home/u/work/proj"
+panicked at src\librarian\tools\doctor.rs:2541
+
+# outside_roots_by_project_counts_elided_rows_too
+looked up entry for "/elsewhere/alpha" -> Null (expected Number(13))
+```
+
+## Reproduction
+1. `git checkout experiments` at `5b54848fd2a4e7fe5da6bf277dc85de39958ff27`
+2. `cargo +1.97.1-x86_64-pc-windows-gnu test --release --features server-stack --lib librarian::tools::doctor::tests::outside_roots_by_project_counts_elided_rows_too librarian::tools::doctor::tests::outside_roots_group_uses_the_project_prefix_before_docs -- --nocapture`
+3. Observe the failures above.
+
+## Environment
+Windows 11 Enterprise 10.0.26200 (VDI), `1.97.1-x86_64-pc-windows-gnu`
+toolchain (host toolchain forced to gnu — this VDI has no MSVC C++ Build
+Tools; see `docs/issues/archive/2026-08-08-cyberark-epm-blocks-ort-sys-build-script.md`).
+`codescout` repo, `experiments` branch.
+
+## Root cause
+`src/librarian/tools/doctor.rs:831-843`:
+```rust
+fn outside_roots_group(path: &str) -> String {
+    let p = std::path::Path::new(path);
+    let mut prefix = std::path::PathBuf::new();
+    for comp in p.components() {
+        if comp.as_os_str() == "docs" {
+            return prefix.to_string_lossy().into_owned();
+        }
+        prefix.push(comp);
+    }
+    ...
+}
+```
+The function's own doc comment calls it "deliberately a *reporting* key, not
+a managed-root lookup" — i.e. it should be pure string manipulation over a
+POSIX-contract path, not real filesystem-path semantics. `PathBuf::push` +
+`to_string_lossy` round-trip transparently on POSIX hosts but re-serialize
+with Windows' native `\` separator regardless of the input's separators —
+exactly the `Path::display()`-on-POSIX-data mistake `c8902da802c0117d`
+already fixed once, in a different call site.
+
+The map-key failure (`outside_roots_by_project_counts_elided_rows_too`) is
+the same bug one level removed: `.entry(outside_roots_group(&v.path))` at
+`doctor.rs:264` inserts under a backslash-separated key on Windows, so a
+POSIX-style lookup key (`"/elsewhere/alpha"`) misses.
+
+*Measured 2026-08-19 (subagent investigation): reproduced via
+`cargo +1.97.1-x86_64-pc-windows-gnu test ... -- --nocapture`, actual vs
+expected strings captured above.*
+
+## Evidence
+### Subagent investigation (2026-08-19)
+Both `outside_roots_group()` (doctor.rs:831-843) and its two unit tests
+were introduced together, fresh, in commit `27309362` ("fix(doctor): make
+the outside-roots sample stable and its remainder reachable", 2026-08-14) —
+part of the experiments fast-forward, never previously exercised on a
+Windows host/toolchain.
+
+## Hypotheses tried
+1. **Hypothesis:** Windows `PathBuf` round-tripping silently normalizes
+   separators, breaking a function contractually meant to stay POSIX-style.
+   **Test:** Read `outside_roots_group`'s implementation and doc comment;
+   compared actual vs expected test output.
+   **Verdict:** confirmed.
+   **Evidence link:** Root cause section above.
+
+## Fix
+Not yet implemented. `outside_roots_group` should operate on the path as a
+plain string (split on `/` directly, or normalize with the project's
+existing `to_forward_slash` helper — see `src/util/fs.rs`) instead of
+routing through `std::path::Path`/`PathBuf`, since the function's own
+contract says it isn't doing real filesystem-path work.
+
+## Tests added
+N/A — not yet fixed. The two existing tests (`doctor.rs:2482-2508`,
+`doctor.rs:2540-2551`) already cover this once corrected.
+
+## Workarounds
+None needed for correctness on POSIX hosts (the bug is Windows-only); on
+Windows, the "outside roots" doctor report's grouping/counts are unreliable
+until fixed.
+
+## Resume
+Rewrite `outside_roots_group` (`src/librarian/tools/doctor.rs:831-843`) to
+do string-only prefix extraction (no `std::path::Path`/`PathBuf`), matching
+the pattern the project's `to_forward_slash` helper already uses elsewhere.
+Re-run the two cited tests to confirm.
+
+## References
+- `src/librarian/tools/doctor.rs:831-843` (`outside_roots_group`)
+- `src/librarian/tools/doctor.rs:264` (map-key call site)
+- `src/librarian/tools/doctor.rs:2482-2508`, `:2540-2551` (the two failing tests)
+- `c8902da802c0117d` (fixed, archived) — prior instance of the same defect class
+- commit `27309362` ("fix(doctor): make the outside-roots sample stable and its remainder reachable")

--- a/docs/issues/2026-08-19-event-create-test-thread-local-missing-clippy-allow.md
+++ b/docs/issues/2026-08-19-event-create-test-thread-local-missing-clippy-allow.md
@@ -1,0 +1,75 @@
+---
+status: fixed
+opened: 2026-08-19
+closed: 2026-08-19
+severity: low
+owner: marius
+related: []
+tags: [clippy, windows, test-only]
+kind: bug
+---
+
+# BUG: `INJECT_FAIL_AFTER_EVENT_INSERT` test thread_local missing the scoped clippy allow its sibling already documents
+
+## Summary
+`src/librarian/tools/event_create.rs`'s test-only `INJECT_FAIL_AFTER_EVENT_INSERT`
+thread_local (line 481) already uses the correct `const { ... }` initializer
+but was missing the `#[allow(clippy::missing_const_for_thread_local)]`
+scoped allow that its sibling `GENERATOR` thread_local (line 250-252, in
+`next_monotonic_id`) already carries with an explanatory comment for the
+exact same known clippy false-positive on this Windows toolchain. Blocked
+`cargo clippy --all-targets -- -D warnings`.
+
+## Symptom (Effect)
+```
+error: initializer for `thread_local` value can be made `const`
+   --> src\librarian\tools\event_create.rs:481:5
+    = note: `-D clippy::missing-const-for-thread-local` implied by `-D warnings`
+error: could not compile `codescout` (lib test) due to 1 previous error
+```
+
+## Reproduction
+1. `git checkout experiments` (any commit from before this fix)
+2. `cargo +1.97.1-x86_64-pc-windows-gnu clippy --release --features server-stack --all-targets -- -D warnings`
+3. Observe the error above.
+
+## Environment
+Windows 11 Enterprise 10.0.26200 (VDI), `1.97.1-x86_64-pc-windows-gnu`
+toolchain. `codescout` repo, `experiments` branch. Not Windows-specific in
+principle, but the sibling comment notes this false-positive is specific to
+the Windows toolchain's clippy build.
+
+## Root cause
+Pre-existing, unrelated to any of the 2026-08-19 Windows-test-suite fixes —
+confirmed via `git status` that `event_create.rs` was untouched by any of
+those. Simply an oversight: when the `GENERATOR` thread_local
+(`next_monotonic_id`, line 259-263) got its scoped allow for this exact
+clippy false-positive, the test-module's `INJECT_FAIL_AFTER_EVENT_INSERT`
+thread_local (added separately) did not receive the same treatment.
+
+## Evidence
+Discovered running the final `cargo clippy --all-targets -- -D warnings`
+verification gate after landing 5 unrelated bug fixes on this branch — the
+gate was otherwise clean until this surfaced.
+
+## Fix
+Added the same `#[allow(clippy::missing_const_for_thread_local)]` (with a
+comment cross-referencing the sibling) directly above the `thread_local! {`
+block at `src/librarian/tools/event_create.rs:481`, matching the existing
+pattern at line 250-252.
+
+Fixed on `experiments`, base commit `66ed27dea7f48557ddfa25886527f5d6c1a7ccaa`
+(fast-forward — no separate master SHA needed).
+
+## Tests added
+N/A — clippy-only, no runtime behavior change. `cargo clippy --all-targets -- -D warnings` clean afterward is the confirmation.
+
+## Workarounds
+N/A — fixed immediately on discovery.
+
+## Resume
+Fixed. N/A.
+
+## References
+- `src/librarian/tools/event_create.rs:250-252` (the sibling pattern this copies)
+- `src/librarian/tools/event_create.rs:481` (the fix site)

--- a/docs/issues/2026-08-19-memory-embedder-test-missing-envguard-for-embedder-url.md
+++ b/docs/issues/2026-08-19-memory-embedder-test-missing-envguard-for-embedder-url.md
@@ -1,0 +1,123 @@
+---
+status: open
+opened: 2026-08-19
+closed:
+severity: low
+owner: marius
+related: []
+tags: [test-isolation, embedder]
+kind: bug
+---
+
+# BUG: `memory_embedder_is_built_from_the_shared_code_embedder` lacks the `EnvGuard` its sibling test uses, so it depends on ambient embedder config instead of testing what it claims to
+
+## Summary
+`agent::tests::memory_embedder_is_built_from_the_shared_code_embedder`
+(`src/agent/mod.rs`) fails before it ever reaches its actual assertion
+(`Arc::ptr_eq` on `CodeDenseAdapter`) because it doesn't pin
+`CODESCOUT_EMBEDDER_URL` the way its neighboring test in the same file does.
+It hits ambient default config, tries to resolve the default
+`local:AllMiniLML6V2Q` model, and panics on `.unwrap()` when no local-embed
+backend is compiled in. This is a test-isolation gap, not a production bug
+and not a feature-gate issue.
+
+## Symptom (Effect)
+```
+thread panicked at src/agent/mod.rs:2309:
+called `Result::unwrap()` on an `Err` value: could not build the
+'local:AllMiniLML6V2Q' embedder: Local embedding requires the
+'local-embed' feature.
+```
+
+## Reproduction
+1. `git checkout experiments` at `5b54848fd2a4e7fe5da6bf277dc85de39958ff27`
+2. `cargo +1.97.1-x86_64-pc-windows-gnu test --release --features server-stack --lib agent::tests::memory_embedder_is_built_from_the_shared_code_embedder -- --nocapture`
+   (built WITHOUT `local-embed`/`local-embed-dynamic` — see
+   `docs/issues/archive/2026-08-08-cyberark-epm-blocks-ort-sys-build-script.md`)
+3. Observe the panic above.
+
+## Environment
+Windows 11 Enterprise 10.0.26200 (VDI), `1.97.1-x86_64-pc-windows-gnu`
+toolchain, default features (`remote-embed, http, librarian`) + `server-stack`,
+no `local-embed`. `codescout` repo, `experiments` branch. Likely also
+reproducible on any host without cached ONNX weights / network access even
+WITH `local-embed` compiled in, per the sibling test's own comment (see Root
+cause).
+
+## Root cause
+`agent.memory_embedder()` (`src/agent/mod.rs:1845-1860`) is itself
+feature-agnostic — it wraps whatever `RetrievalClient::from_env().embedder`
+resolves to. Resolution happens in `build_embedder`
+(`src/retrieval/client.rs:260-296`), which falls back to
+`config.model` (`default_embed_model()`, `src/config/project.rs:347-349` →
+`"local:AllMiniLML6V2Q"`) whenever `[embeddings].url` /
+`CODESCOUT_EMBEDDER_URL` isn't set. `local-embed` is not a default Cargo
+feature (`Cargo.toml:175`), so this path fails whenever it isn't explicitly
+compiled in — and per the sibling test's comment, would fail even with
+`local-embed` compiled in on a host without cached weights or network.
+
+The sibling test in the same file,
+`semantic_memory_store_bootstrap_times_out_on_hung_qdrant`
+(`src/agent/mod.rs:2241-2288`), explicitly guards against exactly this
+class of failure:
+```rust
+// a host with a local model configured would make this test perform a
+// real ONNX load (or fail if weights are absent)... the timeout guard
+// this test exists to pin would silently stop being exercised.
+EnvGuard::set("CODESCOUT_EMBEDDER_URL", "http://unused.invalid");
+```
+`memory_embedder_is_built_from_the_shared_code_embedder` was introduced in
+the same feature work (`git log -S` → `bc79f98c`/`b3aaf820`) but omits that
+guard.
+
+## Evidence
+### Subagent investigation (2026-08-19)
+Confirmed by reading both tests side-by-side in `src/agent/mod.rs` — the
+sibling test's `EnvGuard::set("CODESCOUT_EMBEDDER_URL", ...)` call has no
+counterpart in the failing test.
+
+## Hypotheses tried
+1. **Hypothesis:** This is the same class of "expected failure" as
+   `workspace(status)` reporting `embedding_backend: "unavailable"` when
+   `local-embed` isn't compiled in — i.e. a `#[cfg(feature = "local-embed")]`
+   gate would be the right fix.
+   **Test:** Read what the test actually asserts (`Arc::ptr_eq` on
+   `CodeDenseAdapter` — embedder *identity* wiring, unrelated to which
+   backend is active) and compared against the sibling test's guard
+   pattern.
+   **Verdict:** rejected — a feature gate would mask the real gap (the
+   test's dependence on ambient config) rather than close it. The
+   `Arc::ptr_eq` assertion the test is actually about would still be
+   worth running on a `local-embed` build with a missing-weights host,
+   which the sibling test's comment explicitly anticipates as a failure
+   mode too.
+
+## Fix
+Not yet implemented. Add the same `EnvGuard::set("CODESCOUT_EMBEDDER_URL",
+"http://unused.invalid")` pattern (or equivalent) that
+`semantic_memory_store_bootstrap_times_out_on_hung_qdrant` already uses, so
+`memory_embedder_is_built_from_the_shared_code_embedder` forces the cheap
+HTTP branch and actually reaches its `Arc::ptr_eq` assertion regardless of
+build features or host state.
+
+## Tests added
+N/A — not yet fixed; this bug file *is* about the test itself.
+
+## Workarounds
+Set `CODESCOUT_EMBEDDER_URL` to any reachable (or even unreachable, per the
+sibling test's pattern) HTTP endpoint before running this specific test.
+
+## Resume
+Add the missing `EnvGuard` to
+`agent::tests::memory_embedder_is_built_from_the_shared_code_embedder`
+(`src/agent/mod.rs`, near line 2309), mirroring
+`semantic_memory_store_bootstrap_times_out_on_hung_qdrant`
+(`src/agent/mod.rs:2241-2288`).
+
+## References
+- `src/agent/mod.rs:1845-1860` (`memory_embedder`)
+- `src/agent/mod.rs:2241-2288` (sibling test with the correct guard pattern)
+- `src/agent/mod.rs:2309` (the failing assertion)
+- `src/retrieval/client.rs:260-296` (`build_embedder`)
+- `src/config/project.rs:347-349` (`default_embed_model`)
+- `Cargo.toml:175` (default features)

--- a/docs/issues/2026-08-19-memory-embedder-test-missing-envguard-for-embedder-url.md
+++ b/docs/issues/2026-08-19-memory-embedder-test-missing-envguard-for-embedder-url.md
@@ -1,7 +1,7 @@
 ---
-status: open
+status: fixed
 opened: 2026-08-19
-closed:
+closed: 2026-08-19
 severity: low
 owner: marius
 related: []
@@ -93,27 +93,44 @@ counterpart in the failing test.
    mode too.
 
 ## Fix
-Not yet implemented. Add the same `EnvGuard::set("CODESCOUT_EMBEDDER_URL",
-"http://unused.invalid")` pattern (or equivalent) that
-`semantic_memory_store_bootstrap_times_out_on_hung_qdrant` already uses, so
-`memory_embedder_is_built_from_the_shared_code_embedder` forces the cheap
-HTTP branch and actually reaches its `Arc::ptr_eq` assertion regardless of
-build features or host state.
 
+Added `let _embedder_url = EnvGuard::set("CODESCOUT_EMBEDDER_URL", "http://unused.invalid");`
+to `agent::tests::memory_embedder_is_built_from_the_shared_code_embedder`
+(`src/agent/mod.rs:2318`, inside the function body starting `src/agent/mod.rs:2305`),
+mirroring the sibling test's guard pattern
+(`semantic_memory_store_bootstrap_times_out_on_hung_qdrant`, `src/agent/mod.rs:2241-2288`)
+exactly — same `EnvGuard::set` call, same `let _<name> = ...` RAII binding so the guard
+restores the original env var on drop at the end of the test.
+
+This forces `build_embedder` (`src/retrieval/client.rs:260-296`) down the cheap remote/HTTP
+branch instead of falling through to `default_embed_model()`'s
+`"local:AllMiniLML6V2Q"` (`src/config/project.rs:347-349`), which requires the `local-embed`
+feature and/or cached ONNX weights.
+
+Verified on `experiments` @ `66ed27dea7f48557ddfa25886527f5d6c1a7ccaa`:
+
+```
+cargo +1.97.1-x86_64-pc-windows-gnu test --release --features server-stack --lib agent::tests::memory_embedder_is_built_from_the_shared_code_embedder -- --nocapture
+```
+
+- Before the fix: panicked at `src/agent/mod.rs:2309:84` exactly as described in Symptom.
+- After the fix: `test agent::tests::memory_embedder_is_built_from_the_shared_code_embedder ... ok`
+  — confirmed this is the real pass (not just avoiding the panic): the test body's only
+  assertion, `Arc::ptr_eq(&adapter.0, &seen_client_embedder)`, executes and succeeds, along
+  with the two `.expect()` calls preceding it (`test_seen_client_embedder` capture,
+  `CodeDenseAdapter` downcast).
+
+Fast-forward branch — no separate master SHA to record.
 ## Tests added
-N/A — not yet fixed; this bug file *is* about the test itself.
 
+No new test — the existing test itself was the defect (missing `EnvGuard`); it now passes for real, exercising its actual `Arc::ptr_eq` assertion. See `## Fix` for the confirming test output.
 ## Workarounds
 Set `CODESCOUT_EMBEDDER_URL` to any reachable (or even unreachable, per the
 sibling test's pattern) HTTP endpoint before running this specific test.
 
 ## Resume
-Add the missing `EnvGuard` to
-`agent::tests::memory_embedder_is_built_from_the_shared_code_embedder`
-(`src/agent/mod.rs`, near line 2309), mirroring
-`semantic_memory_store_bootstrap_times_out_on_hung_qdrant`
-(`src/agent/mod.rs:2241-2288`).
 
+Fixed. N/A.
 ## References
 - `src/agent/mod.rs:1845-1860` (`memory_embedder`)
 - `src/agent/mod.rs:2241-2288` (sibling test with the correct guard pattern)

--- a/docs/issues/2026-08-19-rendezvous-parent-pid-stub-returns-zero-on-windows.md
+++ b/docs/issues/2026-08-19-rendezvous-parent-pid-stub-returns-zero-on-windows.md
@@ -1,0 +1,116 @@
+---
+status: open
+opened: 2026-08-19
+closed:
+severity: medium
+owner: marius
+related: []
+tags: [windows, rendezvous, hooks]
+kind: bug
+---
+
+# BUG: `parent_pid()` is a hardcoded `0` stub on Windows, breaking the rendezvous PID-hook match on every Windows host
+
+## Summary
+`src/tools/rendezvous.rs`'s Windows implementation of `parent_pid()` always
+returns `0` — it was never implemented, only stubbed with a comment framing
+`0` as a safe "never matched" degradation. The unit test added in the same
+commit asserts the recorded PPID is nonzero, so it fails deterministically.
+This is not specific to this VDI or sandbox: the stub is `#[cfg(windows)]`,
+so any Windows host hits the same `0`.
+
+## Symptom (Effect)
+```
+thread 'tools::rendezvous::tests::publish_records_the_parent_pid_the_hook_matches_on' panicked at src\tools\rendezvous.rs:246:9:
+assertion `left != right` failed: ppid must be recorded
+  left: 0
+ right: 0
+```
+
+## Reproduction
+1. `git checkout experiments` at `5b54848fd2a4e7fe5da6bf277dc85de39958ff27`
+2. `cargo +1.97.1-x86_64-pc-windows-gnu test --release --features server-stack --lib tools::rendezvous::tests::publish_records_the_parent_pid_the_hook_matches_on -- --nocapture`
+3. Observe the panic above.
+
+## Environment
+Windows 11 Enterprise 10.0.26200 (VDI), `1.97.1-x86_64-pc-windows-gnu`
+toolchain (host toolchain forced to gnu since this VDI has no MSVC C++
+Build Tools installed — see
+`docs/issues/archive/2026-08-08-cyberark-epm-blocks-ort-sys-build-script.md`
+for the unrelated reason `local-embed`/`local-embed-dynamic` are also off
+in this build). `codescout` repo, `experiments` branch.
+
+## Root cause
+`src/tools/rendezvous.rs:158-163`:
+```rust
+#[cfg(windows)]
+fn parent_pid() -> u32 {
+    // No getppid here. The hook walks ancestry itself, so a zero degrades to
+    // "never matched" rather than to a WRONG match — the safe direction.
+    0
+}
+```
+versus the Unix branch (`:153-156`) which calls `libc::getppid()`. The
+Windows PPID path was never implemented — this always returns `0`
+unconditionally, regardless of caller. The companion test
+(`src/tools/rendezvous.rs:240-247`) asserts `ppid != 0`, a correctness
+assumption the Windows stub can never satisfy.
+
+*Measured 2026-08-19: reproduced via `cargo test` through the
+run_command→bash→cargo chain AND via direct invocation of the compiled test
+binary (`target/release/deps/codescout-*.exe <test> --exact --nocapture`) —
+identical `left: 0 right: 0` panic both ways, ruling out process-nesting
+as the cause. The stub returns 0 regardless of caller.*
+
+## Evidence
+### Subagent investigation (2026-08-19)
+```
+git log confirms parent_pid() and this exact test were both introduced
+together in commit 87e85bf2 ("feat(rendezvous): publish a pid-keyed slot
+for the companion to stamp"), dated 2026-08-18 — brand-new code from the
+experiments fast-forward, not long-standing.
+```
+
+## Hypotheses tried
+1. **Hypothesis:** The `0` is a process-nesting artifact of this session's
+   `run_command` → Git Bash → cargo → test-binary spawn chain, not a real
+   bug.
+   **Test:** Ran the test both through the normal `cargo test` wrapper and
+   by directly invoking the compiled test binary, bypassing bash/cargo.
+   **Verdict:** rejected — identical panic both ways.
+   **Evidence link:** Evidence section above.
+2. **Hypothesis:** `parent_pid()` on Windows is an intentional, permanent
+   stub (per its own comment) and the test is simply wrong to assert
+   nonzero.
+   **Test:** Read `src/tools/rendezvous.rs:158-163` directly.
+   **Verdict:** confirmed as the proximate cause — the stub is real and
+   unconditional. Whether the *right* fix is "implement real Windows PPID
+   detection" or "adjust the test to accept 0 as valid on Windows" is
+   still open — see Fix.
+
+## Fix
+Not yet implemented. Two candidate directions:
+(a) Implement real Windows PPID detection (`CreateToolhelp32Snapshot` +
+`PROCESSENTRY32` walk, or the `sysinfo` crate if already a dependency) so
+the hook-matching feature actually works on Windows.
+(b) If the feature is intentionally POSIX-only for now, gate the test
+`#[cfg(unix)]` and document that the Windows rendezvous hook-match is a
+known no-op until (a) lands.
+
+## Tests added
+N/A — not yet fixed.
+
+## Workarounds
+None; the rendezvous PID-hook match silently never fires on Windows
+(degrades to "never matched" per the stub's own design intent, not a crash).
+
+## Resume
+Decide (a) vs (b) above with the person who owns the rendezvous/companion
+hook feature, then either implement Windows PPID detection in
+`src/tools/rendezvous.rs:158-163` or add `#[cfg(unix)]` to the test at
+`src/tools/rendezvous.rs:240-247` and document the Windows gap.
+
+## References
+- `src/tools/rendezvous.rs:153-163` (parent_pid, both platform branches)
+- `src/tools/rendezvous.rs:240-247` (the failing test)
+- commit `87e85bf2` ("feat(rendezvous): publish a pid-keyed slot for the companion to stamp")

--- a/docs/issues/2026-08-19-rendezvous-parent-pid-stub-returns-zero-on-windows.md
+++ b/docs/issues/2026-08-19-rendezvous-parent-pid-stub-returns-zero-on-windows.md
@@ -1,7 +1,7 @@
 ---
-status: open
+status: fixed
 opened: 2026-08-19
-closed:
+closed: 2026-08-19
 severity: medium
 owner: marius
 related: []
@@ -89,27 +89,77 @@ experiments fast-forward, not long-standing.
    still open — see Fix.
 
 ## Fix
-Not yet implemented. Two candidate directions:
-(a) Implement real Windows PPID detection (`CreateToolhelp32Snapshot` +
-`PROCESSENTRY32` walk, or the `sysinfo` crate if already a dependency) so
-the hook-matching feature actually works on Windows.
-(b) If the feature is intentionally POSIX-only for now, gate the test
-`#[cfg(unix)]` and document that the Windows rendezvous hook-match is a
-known no-op until (a) lands.
+Implemented direction (a): real Windows PPID detection via a
+`CreateToolhelp32Snapshot` + `Process32FirstW`/`Process32NextW` walk
+(`windows-sys`'s `Win32_System_Diagnostics_ToolHelp` bindings — Windows has
+no `getppid()`, so the parent PID has to be read off this process's own
+`PROCESSENTRY32W` entry in a full-process snapshot).
 
+`Cargo.toml`: added the `Win32_System_Diagnostics_ToolHelp` feature to the
+existing `[target.'cfg(windows)'.dependencies] windows-sys` entry.
+
+`src/tools/rendezvous.rs:159-193` (replacing the old `0` stub):
+```rust
+#[cfg(windows)]
+fn parent_pid() -> u32 {
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+
+    let pid = std::process::id();
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return 0;
+    }
+    let mut entry = PROCESSENTRY32W {
+        dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+        ..Default::default()
+    };
+    let mut ppid = 0u32;
+    unsafe {
+        if Process32FirstW(snapshot, &mut entry) != 0 {
+            loop {
+                if entry.th32ProcessID == pid {
+                    ppid = entry.th32ParentProcessID;
+                    break;
+                }
+                if Process32NextW(snapshot, &mut entry) == 0 {
+                    break;
+                }
+            }
+        }
+        CloseHandle(snapshot);
+    }
+    ppid
+}
+```
+The `snapshot == INVALID_HANDLE_VALUE` / "this process not found in its own
+snapshot" paths still return `0`, preserving the original stub's safe
+"never matched" degradation for the failure case — only the success path
+changed from always-`0` to an actual PPID.
+
+Fixed on `experiments`, base commit `66ed27dea7f48557ddfa25886527f5d6c1a7ccaa`
+(fast-forward branch — no separate master SHA needed, per this repo's
+CLAUDE.md git-workflow section).
 ## Tests added
-N/A — not yet fixed.
+No new test — the existing
+`tools::rendezvous::tests::publish_records_the_parent_pid_the_hook_matches_on`
+(`src/tools/rendezvous.rs:240-247`) is the regression test; it now exercises
+real Windows PPID detection instead of failing against the old stub.
 
+Verified 2026-08-19 (Windows, `1.97.1-x86_64-pc-windows-gnu`, release +
+`server-stack`):
+```
+test tools::rendezvous::tests::publish_records_the_parent_pid_the_hook_matches_on ... ok
+```
 ## Workarounds
 None; the rendezvous PID-hook match silently never fires on Windows
 (degrades to "never matched" per the stub's own design intent, not a crash).
 
 ## Resume
-Decide (a) vs (b) above with the person who owns the rendezvous/companion
-hook feature, then either implement Windows PPID detection in
-`src/tools/rendezvous.rs:158-163` or add `#[cfg(unix)]` to the test at
-`src/tools/rendezvous.rs:240-247` and document the Windows gap.
-
+Fixed. N/A.
 ## References
 - `src/tools/rendezvous.rs:153-163` (parent_pid, both platform branches)
 - `src/tools/rendezvous.rs:240-247` (the failing test)

--- a/docs/issues/2026-08-19-windows-native-test-suite-posix-path-assumptions.md
+++ b/docs/issues/2026-08-19-windows-native-test-suite-posix-path-assumptions.md
@@ -1,0 +1,195 @@
+---
+status: open
+opened: 2026-08-19
+closed:
+severity: low
+owner: marius
+related: []
+tags: [windows, test-design, path-handling]
+kind: bug
+---
+
+# BUG: 9 tests across 4 files fail when run natively on Windows because they hardcode POSIX-only path literals/assumptions, with no production impact
+
+## Summary
+Running the full `cargo test` suite natively on Windows for the first time
+(this VDI, gnu toolchain, after the experiments fast-forward) surfaced 9
+previously-uncaught test failures across `src/config/global.rs`,
+`src/util/path_security.rs`, `src/tools/config/tests.rs`, and
+`src/tools/core/tests.rs`. All 9 are test-design gaps that assume POSIX
+path semantics — none indicate a production defect; in each case the
+underlying implementation is either confirmed correct or the test fixture
+itself constructs an input real production code paths never produce.
+Bundled into one bug file since each individual test is a small, related
+instance of "test never had Windows coverage," rather than filing 4+
+separate near-duplicate reports.
+
+## Symptom (Effect)
+```
+# src/config/global.rs (3 tests — same cause)
+config::global::tests::config_dir_prefers_xdg_config_home ... FAILED (Option::unwrap() on None)
+config::global::tests::config_dir_xdg_wins_over_home ... FAILED
+config::global::tests::env_path_derives_from_config_dir ... FAILED
+
+# src/util/path_security.rs (2 tests — 2 distinct causes)
+util::path_security::tests::hard_denials_say_that_approve_write_will_not_help ... FAILED
+util::path_security::tests::an_option_glob_does_not_force_the_in_project_verdict ... FAILED
+
+# src/tools/config/tests.rs + src/tools/core/tests.rs (3 tests — 2 distinct causes)
+tools::config::tests::a_worktree_whose_main_has_workspace_toml_reports_inherited_topology ... FAILED
+tools::config::tests::activating_a_linked_worktree_reports_the_divergence_it_creates ... FAILED
+tools::core::tests::a_read_says_which_tree_it_answered_from_when_worktrees_are_unchosen ... FAILED
+
+# src/memory/filter.rs (1 test — different cause: --release strips debug_assert!)
+memory::filter::tests::filter_sections_empty_sections_is_caller_error - should panic ... FAILED
+note: test did not panic as expected
+```
+
+## Reproduction
+1. `git checkout experiments` at `5b54848fd2a4e7fe5da6bf277dc85de39958ff27`
+2. `cargo +1.97.1-x86_64-pc-windows-gnu test --release --features server-stack --lib`
+3. Observe the 9 failures above (out of 14 total that session; the other 5
+   are filed as separate genuine-bug reports — see References).
+
+## Environment
+Windows 11 Enterprise 10.0.26200 (VDI), `1.97.1-x86_64-pc-windows-gnu`
+toolchain (host toolchain forced to gnu — this VDI has no MSVC C++ Build
+Tools; see `docs/issues/archive/2026-08-08-cyberark-epm-blocks-ort-sys-build-script.md`).
+`codescout` repo, `experiments` branch.
+
+## Root cause
+Four distinct mechanisms, one per cluster:
+
+**1. `config::global` ×3** (`src/config/global.rs:245-303`): all three tests
+call `global_config_dir_from(Some(OsStr::new("/tmp/...")), ...)`.
+`global_config_dir_from` (`:49-61`) filters on `PathBuf::is_absolute()` —
+but `PathBuf::from("/tmp/...")` is **not** absolute on Windows (Windows
+requires a drive letter or UNC prefix; a bare `/`-rooted path is
+"has_root" but not "absolute"). The filter rejects it, falls through to
+`home` (also `None` in these tests), and `.unwrap()` panics on the
+resulting `None`.
+
+**2. `path_security` ×2** (`src/util/path_security.rs`):
+- `hard_denials_say_that_approve_write_will_not_help` (exercises
+  `classify_write_path`, `:273-373`) relies on the comment-stated invariant
+  "`..` only survives canonicalization when an intermediate directory does
+  not exist" — true on POSIX (component-by-component `readdir`), **false
+  on Windows**, where `CreateFileW`'s NT path translation lexically
+  collapses `dir\..` pairs as pure string manipulation before any
+  filesystem lookup. The hard-denial branch (`:308-320`) never fires.
+- `an_option_glob_does_not_force_the_in_project_verdict` (exercises
+  `check_source_file_access` → `segment_reads_project_source`,
+  `:1398-1422`) relies on `Path::is_absolute()` being true for a
+  driveless POSIX-style path (`/home/u/work/otherrepo`) — false on
+  Windows, same underlying std/Win32 semantics as cluster 1.
+
+**3. worktree topology ×3** (`src/tools/config/tests.rs`,
+`src/tools/core/tests.rs`):
+- Two tests (`a_worktree_whose_main_has_workspace_toml_reports_inherited_topology`,
+  `activating_a_linked_worktree_reports_the_divergence_it_creates`)
+  pre-canonicalize their fixture's base dir to a `\\?\`-verbatim Windows
+  path *before* writing a fake `.git` worktree pointer file. Windows
+  verbatim (`\\?\`) paths only treat `\` as a separator, not `/`, so
+  `is_linked_worktree`'s `Path::components()` walk
+  (`src/util/path_security.rs:518-538`) never yields a `"worktrees"`
+  component — the whole `/main/.git/worktrees/feat` suffix collapses into
+  one opaque literal, and `is_linked_worktree` returns `false`. Real
+  `git worktree add` never writes `\\?\`-prefixed pointers, so production
+  is unaffected — this is purely a test-fixture bug.
+- `a_read_says_which_tree_it_answered_from_when_worktrees_are_unchosen`
+  compares JSON-serialized tool output (backslashes escaped as `\\`)
+  against `Path::display()`'s raw single-backslash form
+  (`.contains(&wt.display().to_string())`) — can never match once the
+  path contains a backslash, i.e. always on Windows. A missing
+  escape-awareness bug in the assertion itself, trivially passes on POSIX
+  (no backslashes to escape).
+
+**4. `memory::filter` ×1** (`src/memory/filter.rs:298-302`): a
+`#[should_panic(expected = "precondition")]` test relying on
+`debug_assert!` (`:91-94`), which compiles out entirely in `--release`
+builds. The test's own comment and the function's doc comment both state
+this caveat explicitly — this cluster is *not* a Windows issue at all, it
+fails identically in any `--release` build on any OS; it just happened to
+surface in this session because the build used `--release`.
+
+*Measured 2026-08-19: all reproduced via
+`cargo +1.97.1-x86_64-pc-windows-gnu test --release --features server-stack --lib
+<test> -- --nocapture`; root causes 1–3 confirmed by direct source reading
+(std/Win32 path semantics) and, for cluster 3, an independent standalone
+repro compiled with the same toolchain. Cluster 4 confirmed by the test's
+own inline documentation.*
+
+## Evidence
+### Subagent investigation (2026-08-19)
+Four parallel investigations (path_security, worktree topology, config
+global — diagnosed inline by the main session — and memory filter) each
+independently confirmed no production-code path is affected; see the
+per-cluster mechanism descriptions above, each citing the exact
+file:line evidence.
+
+## Hypotheses tried
+1. **Hypothesis:** These are regressions introduced by the 550-commit
+   experiments fast-forward.
+   **Test:** `git log` on each affected file/test to find when the
+   test and the code it exercises were introduced.
+   **Verdict:** rejected for clusters 1, 2, and 4 — this is the first time
+   these tests have run natively on Windows/gnu, regardless of when the
+   code was written; the assumptions are POSIX-only from the start.
+   Cluster 3's specific tests ARE new (from the merge), but the bug is in
+   the new tests' fixtures, not in the worktree-topology feature they
+   exercise.
+2. **Hypothesis:** Cluster 2 (path_security) indicates an actual security
+   hole — Windows path handling bypassing a write-denial check.
+   **Test:** Read `classify_write_path` and `check_source_file_access` in
+   full; compared what each returns on Windows vs. what the POSIX-authored
+   test expects.
+   **Verdict:** rejected (with moderate confidence — see Resume) — Windows'
+   own `..` collapse and `Path::is_absolute()` semantics don't appear to
+   create a bypass, just a different code path (`Allowed`/`OutsideRoot`
+   instead of the specific hard-`Denied` variant) than the POSIX test
+   expects. Worth a maintainer sanity pass given this is security code.
+
+## Fix
+Not yet implemented, four independent small fixes:
+1. `config::global` tests: use a platform-appropriate absolute path helper
+   in test fixtures instead of hardcoded `/tmp/...` literals (e.g.
+   `std::env::temp_dir()` or a `#[cfg(windows)]`/`#[cfg(unix)]` literal
+   pair).
+2. `path_security` tests: give Windows-aware inputs/expectations — a real
+   drive-relative or verbatim-prefix operand for the outside-root test;
+   for the hard-denial test, either accept `Allowed`/`OutsideRoot` as
+   valid on Windows or construct an unresolvable `..` that Windows also
+   can't lexically collapse (e.g. one where the *parent* directory is
+   itself missing).
+3. worktree tests: don't pre-canonicalize the fixture base dir to a
+   `\\?\`-verbatim path before writing the fake `.git` pointer (tests 1–2);
+   compare against the JSON-escaped form, or use a path-agnostic
+   containment check, in test 3.
+4. `memory::filter` test: either accept `#[cfg(debug_assertions)]`-gating
+   this test, or replace the `debug_assert!` under test with a check that
+   also fires in `--release` if the precondition genuinely must hold
+   there too (product decision, not just a test fix).
+
+## Tests added
+N/A — not yet fixed; this bug file covers pre-existing tests whose fixtures
+need repair.
+
+## Workarounds
+Run the suite with `cargo +<toolchain> test` (debug, not `--release`) to
+avoid cluster 4; the other 8 have no workaround short of skipping them —
+they don't reflect a usable-vs-broken product distinction on Windows.
+
+## Resume
+Work the four fixes independently (see Fix). Prioritize cluster 2
+(path_security) first given it's security-adjacent code, even though the
+initial read suggests no real bypass — get a second pair of eyes on
+`classify_write_path`'s Windows behavior before considering this closed.
+
+## References
+- `src/config/global.rs:49-61,245-303`
+- `src/util/path_security.rs:273-373,1398-1422,2492-2508,3662-3680`
+- `src/tools/config/tests.rs` (~918-923, ~985-990)
+- `src/tools/core/tests.rs:584-594,615`
+- `src/memory/filter.rs:91-94,298-302`
+- `docs/issues/archive/2026-06-09-windows-test-suite-preexisting-failures.md` (prior, already-fixed batch of Windows path issues in the same `path_security.rs` file — same recurring class, different instances)
+- Sibling reports from the same investigation session: rendezvous PPID stub, doctor `outside_roots` separator bug, `artifact(create)` missing `to_forward_slash`, memory-embedder test EnvGuard gap (all filed 2026-08-19)

--- a/docs/issues/2026-08-19-windows-native-test-suite-posix-path-assumptions.md
+++ b/docs/issues/2026-08-19-windows-native-test-suite-posix-path-assumptions.md
@@ -1,7 +1,7 @@
 ---
-status: open
+status: fixed
 opened: 2026-08-19
-closed:
+closed: 2026-08-19
 severity: low
 owner: marius
 related: []
@@ -150,41 +150,85 @@ file:line evidence.
    expects. Worth a maintainer sanity pass given this is security code.
 
 ## Fix
-Not yet implemented, four independent small fixes:
-1. `config::global` tests: use a platform-appropriate absolute path helper
-   in test fixtures instead of hardcoded `/tmp/...` literals (e.g.
-   `std::env::temp_dir()` or a `#[cfg(windows)]`/`#[cfg(unix)]` literal
-   pair).
-2. `path_security` tests: give Windows-aware inputs/expectations — a real
-   drive-relative or verbatim-prefix operand for the outside-root test;
-   for the hard-denial test, either accept `Allowed`/`OutsideRoot` as
-   valid on Windows or construct an unresolvable `..` that Windows also
-   can't lexically collapse (e.g. one where the *parent* directory is
-   itself missing).
-3. worktree tests: don't pre-canonicalize the fixture base dir to a
-   `\\?\`-verbatim path before writing the fake `.git` pointer (tests 1–2);
-   compare against the JSON-escaped form, or use a path-agnostic
-   containment check, in test 3.
-4. `memory::filter` test: either accept `#[cfg(debug_assertions)]`-gating
-   this test, or replace the `debug_assert!` under test with a check that
-   also fires in `--release` if the precondition genuinely must hold
-   there too (product decision, not just a test fix).
+All four clusters fixed independently, on `experiments`, base commit
+`66ed27dea7f48557ddfa25886527f5d6c1a7ccaa` (fast-forward branch — no
+separate master SHA needed):
 
+1. **`config::global` ×3** (`src/config/global.rs`) — added a
+   `#[cfg(windows)]`/`#[cfg(not(windows))]` `test_abs_path(name: &str) ->
+   PathBuf` helper in the `tests` module (`C:\tmp` on Windows, `/tmp`
+   elsewhere) and rewrote all three tests to build their XDG/home inputs
+   from it, asserting against a path derived from the same input rather
+   than a hardcoded literal — the behavior under test (XDG wins over HOME,
+   `.env` derivation) is unchanged. `global_config_dir_from` itself
+   untouched.
+
+2. **`path_security` ×2** (`src/util/path_security.rs`):
+   - `hard_denials_say_that_approve_write_will_not_help`: changed the input
+     from `"no-such-dir-xyz/../escape.rs"` to
+     `"no-such-dir-xyz/../also-missing/escape.rs"` — nesting a second
+     missing directory *after* the `..` so canonicalization fails on both
+     platforms (Windows collapses the first `..` lexically, then fails to
+     canonicalize the still-nonexistent `also-missing`; POSIX fails at
+     `no-such-dir-xyz` before ever reaching `..`). `classify_write_path`
+     untouched — confirmed by direct code reading
+     (`canonicalize_write_target`/`best_effort_canonicalize`, both wrapping
+     plain `std::fs::canonicalize`) that the original input's `Allowed`
+     verdict on Windows was *correct*, not a bypass: Windows' own
+     `CreateFileW` path translation collapses `..` the same way before the
+     real write happens, so the classified path matches where the file
+     actually lands.
+   - `an_option_glob_does_not_force_the_in_project_verdict`: switched the
+     Windows branch's literals from POSIX-style paths to genuinely
+     `is_absolute()` Windows ones (`C:/work/myproj`, `C:/work/otherrepo` —
+     forward slashes, not backslashes: the string is shell-tokenized, and
+     `shell_tokens` treats `\` as a shell escape character, which mangled
+     an initial backslash-style attempt before `Path::new` ever saw it).
+     `check_source_file_access`/`segment_reads_project_source` untouched —
+     confirmed this gate is an advisory shell-command hint (nudging toward
+     `symbols`/`read_file`/`grep`), not an access-control boundary, and the
+     Windows-only mismatch made it *more* conservative (over-blocking), the
+     safe direction for a hint gate.
+
+3. **worktree topology ×3** (`src/tools/config/tests.rs`,
+   `src/tools/core/tests.rs`):
+   - Two tests: the fake `.git` gitdir-pointer string now builds from the
+     pre-canonicalization `dir.path()` instead of the canonicalized `base`
+     — a non-verbatim Windows path lets `Path::components()` split on `/`
+     correctly, where a `\\?\`-verbatim one doesn't.
+   - One test: replaced the raw `.contains(&wt.display().to_string())`
+     check with a JSON-escaped comparison
+     (`.replace('\\', "\\\\")`), matching how the tool's JSON output
+     actually serializes backslashes. `is_linked_worktree` and all other
+     production code untouched, confirmed via `git status`.
+
+4. **`memory::filter` ×1** (`src/memory/filter.rs:298-302`) — added
+   `#[cfg(debug_assertions)]` above `#[test]` so the test only compiles/runs
+   in debug builds, where the `debug_assert!` it exercises is actually
+   active. `filter_sections`'s production `debug_assert!` untouched (a
+   deliberate perf/ergonomics choice elsewhere in this codebase, out of
+   scope for this bug).
 ## Tests added
-N/A — not yet fixed; this bug file covers pre-existing tests whose fixtures
-need repair.
-
+No new tests — the 9 existing tests are themselves the regression coverage,
+now fixed rather than replaced. All verified independently green on
+Windows (`1.97.1-x86_64-pc-windows-gnu`, release + `server-stack`):
+```
+test result: ok. 19 passed; 0 failed  (config::global::tests::, includes the 3 fixed + 16 pre-existing)
+test result: ok. 1 passed  (path_security::hard_denials_say_that_approve_write_will_not_help)
+test result: ok. 1 passed  (path_security::an_option_glob_does_not_force_the_in_project_verdict)
+test result: ok. 3 passed  (worktree topology cluster)
+(memory::filter test verified applied but not independently re-run — see cluster 4 above; debug-mode pass confirmed by the fixing agent, release-mode skip confirmed by absence from the failure list in the final consolidated run)
+```
 ## Workarounds
 Run the suite with `cargo +<toolchain> test` (debug, not `--release`) to
 avoid cluster 4; the other 8 have no workaround short of skipping them —
 they don't reflect a usable-vs-broken product distinction on Windows.
 
 ## Resume
-Work the four fixes independently (see Fix). Prioritize cluster 2
-(path_security) first given it's security-adjacent code, even though the
-initial read suggests no real bypass — get a second pair of eyes on
-`classify_write_path`'s Windows behavior before considering this closed.
-
+Fixed. N/A — cluster 2's "worth a maintainer sanity pass" note from the
+original Hypotheses section was resolved during the fix itself (see Fix
+item 2's code-level confirmation that no bypass exists), so no follow-up
+is outstanding.
 ## References
 - `src/config/global.rs:49-61,245-303`
 - `src/util/path_security.rs:273-373,1398-1422,2492-2508,3662-3680`

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -2305,6 +2305,15 @@ mod tests {
     async fn memory_embedder_is_built_from_the_shared_code_embedder() {
         use crate::retrieval::embedder::{CodeDenseAdapter, DenseEmbedder};
 
+        // Pin the embedder to a remote/HTTP backend so `Agent::new` takes its instant,
+        // zero-I/O branch regardless of ambient `[embeddings]`/env config — mirrors
+        // `semantic_memory_store_bootstrap_times_out_on_hung_qdrant`'s guard. Without
+        // this, a host without `local-embed` compiled in (or without cached ONNX
+        // weights/network even with it compiled in) would panic resolving the default
+        // `local:AllMiniLML6V2Q` model before ever reaching the `Arc::ptr_eq` assertion
+        // below.
+        let _embedder_url = EnvGuard::set("CODESCOUT_EMBEDDER_URL", "http://unused.invalid");
+
         let agent = Agent::new(None).await.unwrap();
         let mem: std::sync::Arc<dyn DenseEmbedder> = agent.memory_embedder().await.unwrap();
 
@@ -2322,7 +2331,7 @@ mod tests {
         assert!(
             std::sync::Arc::ptr_eq(&adapter.0, &seen_client_embedder),
             "memory_embedder's returned adapter must wrap the SAME embedder Arc the \
-             RetrievalClient it built holds — got two different instances"
+                 RetrievalClient it built holds — got two different instances"
         );
     }
 

--- a/src/config/global.rs
+++ b/src/config/global.rs
@@ -241,11 +241,28 @@ mod tests {
     // writes are GONE rather than coordinated. See
     // docs/issues/archive/2026-07-13-test-env-access-ub-nonserial-writers-race-build-tool-context.md
 
+    /// Build a path that is genuinely absolute on the host running the test.
+    /// `PathBuf::is_absolute()` requires a drive letter/UNC prefix on Windows, so the
+    /// POSIX-only `/tmp/...` literals these tests used to hardcode are NOT absolute
+    /// there and `global_config_dir_from`'s `is_absolute()` filter (see its doc
+    /// comment above) rejects them, falling through to `home` (`None` in these
+    /// tests) and panicking the `.unwrap()`. See
+    /// docs/issues/2026-08-19-windows-native-test-suite-posix-path-assumptions.md.
+    #[cfg(windows)]
+    fn test_abs_path(name: &str) -> PathBuf {
+        PathBuf::from(r"C:\tmp").join(name)
+    }
+
+    #[cfg(not(windows))]
+    fn test_abs_path(name: &str) -> PathBuf {
+        PathBuf::from("/tmp").join(name)
+    }
+
     #[test]
     fn config_dir_prefers_xdg_config_home() {
-        let dir =
-            global_config_dir_from(Some(OsStr::new("/tmp/xdg-test-codescout")), None).unwrap();
-        assert_eq!(dir, PathBuf::from("/tmp/xdg-test-codescout/codescout"));
+        let xdg = test_abs_path("xdg-test-codescout");
+        let dir = global_config_dir_from(Some(xdg.as_os_str()), None).unwrap();
+        assert_eq!(dir, xdg.join("codescout"));
     }
 
     #[test]
@@ -256,12 +273,10 @@ mod tests {
 
     #[test]
     fn config_dir_xdg_wins_over_home() {
-        let dir = global_config_dir_from(
-            Some(OsStr::new("/tmp/xdg")),
-            Some(OsStr::new("/tmp/fake-home")),
-        )
-        .unwrap();
-        assert_eq!(dir, PathBuf::from("/tmp/xdg/codescout"));
+        let xdg = test_abs_path("xdg");
+        let home = test_abs_path("fake-home");
+        let dir = global_config_dir_from(Some(xdg.as_os_str()), Some(home.as_os_str())).unwrap();
+        assert_eq!(dir, xdg.join("codescout"));
     }
 
     #[test]
@@ -294,12 +309,9 @@ mod tests {
 
     #[test]
     fn env_path_derives_from_config_dir() {
-        let dir =
-            global_config_dir_from(Some(OsStr::new("/tmp/xdg-test-codescout")), None).unwrap();
-        assert_eq!(
-            dir.join(".env"),
-            PathBuf::from("/tmp/xdg-test-codescout/codescout/.env")
-        );
+        let xdg = test_abs_path("xdg-test-codescout");
+        let dir = global_config_dir_from(Some(xdg.as_os_str()), None).unwrap();
+        assert_eq!(dir.join(".env"), xdg.join("codescout").join(".env"));
     }
 
     #[test]

--- a/src/librarian/tools/create.rs
+++ b/src/librarian/tools/create.rs
@@ -365,7 +365,8 @@ pub async fn call(ctx: &ToolContext, args: Value) -> Result<Value> {
         super::worktree::ensure_registration(&cat, cp)?;
     }
 
-    let mut result = json!({"id": id, "abs_path": row.abs_path.display().to_string()});
+    let mut result =
+        json!({"id": id, "abs_path": crate::util::fs::to_forward_slash(&row.abs_path)});
     if a.kind == "tracker" && a.augment.is_none() {
         result["tracker_hint"] = json!(
             "Tracker created without augmentation. \
@@ -1014,8 +1015,11 @@ mod tests {
         .unwrap();
         let abs = result["abs_path"].as_str().unwrap();
         assert!(abs.ends_with("docs/inferred.md"), "got: {abs}");
+        // abs_path is forward-slash normalized (crate::util::fs::to_forward_slash);
+        // path is a raw TempDir PathBuf, native-separator on Windows, so it must be
+        // normalized the same way before the prefix comparison.
         assert!(
-            abs.starts_with(path.to_string_lossy().as_ref()),
+            abs.starts_with(&crate::util::fs::to_forward_slash(&path)),
             "got: {abs}"
         );
     }
@@ -1046,7 +1050,10 @@ mod tests {
         .unwrap();
         let abs = result["abs_path"].as_str().unwrap();
         let expected = proj_path.join("docs/foo.md");
-        assert_eq!(abs, expected.to_string_lossy());
+        // abs_path is forward-slash normalized (crate::util::fs::to_forward_slash);
+        // PathBuf::join + to_string_lossy stays native-separator on Windows, so
+        // `expected` needs the same normalization before comparing.
+        assert_eq!(abs, crate::util::fs::to_forward_slash(&expected));
     }
 
     #[tokio::test]

--- a/src/librarian/tools/doctor.rs
+++ b/src/librarian/tools/doctor.rs
@@ -829,17 +829,21 @@ fn count_dead_root(
 /// so a truncated sample can still account for every row it dropped, and it
 /// never decides whether a row is a violation.
 fn outside_roots_group(path: &str) -> String {
-    let p = std::path::Path::new(path);
-    let mut prefix = std::path::PathBuf::new();
-    for comp in p.components() {
-        if comp.as_os_str() == "docs" {
-            return prefix.to_string_lossy().into_owned();
-        }
-        prefix.push(comp);
+    let mut segments: Vec<&str> = path.split('/').collect();
+    if let Some(docs_idx) = segments.iter().position(|s| *s == "docs") {
+        return segments[..docs_idx].join("/");
     }
-    p.parent()
-        .map(|d| d.to_string_lossy().into_owned())
-        .unwrap_or_else(|| path.to_string())
+    if segments.len() > 1 {
+        segments.pop();
+        let joined = segments.join("/");
+        if joined.is_empty() && path.starts_with('/') {
+            "/".to_string()
+        } else {
+            joined
+        }
+    } else {
+        String::new()
+    }
 }
 
 /// Pulls every `(id, abs_path)` row once and runs six per-row checks

--- a/src/librarian/tools/doctor.rs
+++ b/src/librarian/tools/doctor.rs
@@ -2562,6 +2562,50 @@ mod tests {
         );
     }
 
+    /// The group key must stay in the forward-slash form the catalog stores.
+    ///
+    /// The bug: this routed through `PathBuf::push`, which renders with the HOST
+    /// separator, so on Windows a forward-slash catalog row came back as
+    /// `C:\work\proj` — a string that is not a prefix of the row it was derived
+    /// from. The catalog stores forward-slash form on every platform (see
+    /// `util::fs::to_forward_slash`), so the key derived from a row has to as well.
+    ///
+    /// Honest about its reach: on POSIX the old and new implementations agree on
+    /// every well-formed row, because `Path` already separates on `/` here. This is
+    /// a characterization test locally and only discriminates when run on Windows —
+    /// which is exactly where the bug lived, and where nothing else was watching.
+    ///
+    /// BUG docs/issues/2026-08-19-doctor-outside-roots-group-rewrites-posix-paths-with-backslashes.md
+    #[test]
+    fn outside_roots_group_keeps_the_forward_slash_form_the_catalog_stores() {
+        for row in [
+            "C:/work/proj/docs/trackers/x.md",
+            "C:/work/proj/notes/x.md",
+            "/home/u/work/proj/docs/trackers/x.md",
+        ] {
+            let group = outside_roots_group(row);
+            assert!(
+                !group.contains('\\'),
+                "group key must stay forward-slash on every host: {row} -> {group}"
+            );
+            assert!(
+                row.starts_with(&group),
+                "group key must be a prefix of the row it groups: {row} -> {group}"
+            );
+        }
+
+        // A drive-lettered row splits on its first `docs` component exactly like a
+        // POSIX one, and falls back to the parent when there is none.
+        assert_eq!(
+            outside_roots_group("C:/work/proj/docs/trackers/x.md"),
+            "C:/work/proj"
+        );
+        assert_eq!(
+            outside_roots_group("C:/work/proj/notes/x.md"),
+            "C:/work/proj/notes"
+        );
+    }
+
     /// `summary.total` must partition `summary.by_check`. Both sit in the same
     /// object and `total` is the headline number a reader takes first.
     ///

--- a/src/librarian/tools/event_create.rs
+++ b/src/librarian/tools/event_create.rs
@@ -483,6 +483,11 @@ pub(crate) mod tests {
         /// event row but before inserting edges. Used by the transaction-rollback
         /// test below to verify atomicity. Thread-local so parallel tests
         /// running on different threads do not race on a shared flag.
+        //
+        // clippy 1.96+ (Windows toolchain) false-positives `missing_const_for_thread_local`
+        // here even though the initializer already uses `const { ... }`. Scoped allow,
+        // same false-positive as `next_monotonic_id`'s GENERATOR above.
+        #[allow(clippy::missing_const_for_thread_local)]
         pub(super) static INJECT_FAIL_AFTER_EVENT_INSERT: std::cell::Cell<bool> =
             const { std::cell::Cell::new(false) };
     }

--- a/src/memory/filter.rs
+++ b/src/memory/filter.rs
@@ -293,6 +293,7 @@ Python patterns here.
         assert!(r.content.contains(" ### Fake"));
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "precondition")]
     fn filter_sections_empty_sections_is_caller_error() {

--- a/src/tools/config/tests.rs
+++ b/src/tools/config/tests.rs
@@ -915,9 +915,17 @@ async fn activating_a_linked_worktree_reports_the_divergence_it_creates() {
     let wt = base.join("main/.worktrees/feat");
     std::fs::create_dir_all(wt.join(".codescout")).unwrap();
     std::fs::write(wt.join("Cargo.toml"), "[package]\nname=\"x\"\n").unwrap();
+    // Build the gitdir pointer from the pre-canonicalization dir path: on Windows,
+    // std::fs::canonicalize() yields a `\\?\`-verbatim path, and verbatim paths only
+    // treat `\` as a separator — a `/`-joined suffix there would never be found by
+    // is_linked_worktree's Path::components() walk. Real `git worktree add` never
+    // writes verbatim pointers, so the non-canonical form here matches production.
     std::fs::write(
         wt.join(".git"),
-        format!("gitdir: {}/main/.git/worktrees/feat\n", base.display()),
+        format!(
+            "gitdir: {}/main/.git/worktrees/feat\n",
+            dir.path().display()
+        ),
     )
     .unwrap();
 
@@ -986,9 +994,17 @@ async fn a_worktree_whose_main_has_workspace_toml_reports_inherited_topology() {
     let wt = base.join("main/.worktrees/feat");
     std::fs::create_dir_all(wt.join(".codescout")).unwrap();
     std::fs::write(wt.join("Cargo.toml"), "[package]\nname=\"x\"\n").unwrap();
+    // Build the gitdir pointer from the pre-canonicalization dir path: on Windows,
+    // std::fs::canonicalize() yields a `\\?\`-verbatim path, and verbatim paths only
+    // treat `\` as a separator — a `/`-joined suffix there would never be found by
+    // is_linked_worktree's Path::components() walk. Real `git worktree add` never
+    // writes verbatim pointers, so the non-canonical form here matches production.
     std::fs::write(
         wt.join(".git"),
-        format!("gitdir: {}/main/.git/worktrees/feat\n", base.display()),
+        format!(
+            "gitdir: {}/main/.git/worktrees/feat\n",
+            dir.path().display()
+        ),
     )
     .unwrap();
 

--- a/src/tools/core/tests.rs
+++ b/src/tools/core/tests.rs
@@ -612,8 +612,13 @@ async fn a_read_says_which_tree_it_answered_from_when_worktrees_are_unchosen() {
         first.contains("_workspace_notice"),
         "the first read must say which tree it resolved against, got: {first}"
     );
+    // `first` is JSON-serialized tool output, so any backslash in the path has
+    // been escaped as `\\`. Path::display() renders a raw single-backslash form
+    // on Windows, which can never match a `.contains()` against escaped JSON —
+    // escape the same way the serializer did before comparing.
+    let wt_json_escaped = wt.display().to_string().replace('\\', "\\\\");
     assert!(
-        first.contains(&wt.display().to_string()),
+        first.contains(&wt_json_escaped),
         "the notice must name the worktree the caller might mean, got: {first}"
     );
     assert!(

--- a/src/tools/rendezvous.rs
+++ b/src/tools/rendezvous.rs
@@ -157,9 +157,46 @@ fn parent_pid() -> u32 {
 
 #[cfg(windows)]
 fn parent_pid() -> u32 {
-    // No getppid here. The hook walks ancestry itself, so a zero degrades to
-    // "never matched" rather than to a WRONG match — the safe direction.
-    0
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+
+    let pid = std::process::id();
+
+    // SAFETY: TH32CS_SNAPPROCESS with a 0 pid snapshots every running process;
+    // th32ProcessID is ignored for this flag per the Win32 docs.
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        // No getppid here — the hook walks ancestry itself, so a zero degrades
+        // to "never matched" rather than to a WRONG match, the safe direction.
+        return 0;
+    }
+
+    let mut entry = PROCESSENTRY32W {
+        dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+        ..Default::default()
+    };
+
+    let mut ppid = 0u32;
+    // SAFETY: `entry` is zero-initialized with `dwSize` set as the API requires;
+    // `snapshot` is the valid handle returned above, closed once below either way.
+    unsafe {
+        if Process32FirstW(snapshot, &mut entry) != 0 {
+            loop {
+                if entry.th32ProcessID == pid {
+                    ppid = entry.th32ParentProcessID;
+                    break;
+                }
+                if Process32NextW(snapshot, &mut entry) == 0 {
+                    break;
+                }
+            }
+        }
+        CloseHandle(snapshot);
+    }
+    ppid
 }
 
 /// Remove slots whose process is gone. Marked cleanup, not discovery — see

--- a/src/util/path_security.rs
+++ b/src/util/path_security.rs
@@ -2496,13 +2496,26 @@ mod tests {
         // root was absolute and outside — with a hint (`grep(pattern, path)`)
         // that resolves against the active project and therefore has no correct
         // invocation for that repo at all.
-        let root = Path::new("/home/u/work/myproj");
+        //
+        // The root/otherrepo literals must be genuinely `Path::is_absolute()` on
+        // the host running the test: a driveless POSIX-style path like
+        // `/home/u/work/otherrepo` has a root but no prefix, so Rust's
+        // `is_absolute()` is false for it on Windows — that silently defeats the
+        // `targets_outside` check this test exists to exercise. Drive-letter
+        // literals on Windows, POSIX-rooted literals elsewhere — forward slashes
+        // on both, since this string is shell-tokenized (`shell_tokens` treats
+        // `\` as a shell escape character, which mangles a backslash-style
+        // Windows path before `Path::new` ever sees it; `C:/...` is still
+        // `is_absolute()` on Windows and survives tokenization intact).
+        #[cfg(windows)]
+        let (root, otherrepo): (&Path, &str) = (Path::new("C:/work/myproj"), "C:/work/otherrepo");
+        #[cfg(not(windows))]
+        let (root, otherrepo): (&Path, &str) =
+            (Path::new("/home/u/work/myproj"), "/home/u/work/otherrepo");
+
         assert!(
-            check_source_file_access(
-                "grep -rn 'x' /home/u/work/otherrepo --include='*.mjs'",
-                root
-            )
-            .is_none(),
+            check_source_file_access(&format!("grep -rn 'x' {otherrepo} --include='*.mjs'"), root)
+                .is_none(),
             "a glob filter beside an out-of-project search root is not a project read"
         );
     }
@@ -3663,12 +3676,24 @@ EOF"#;
         let tmp = tempfile::tempdir().unwrap();
         let cfg = PathSecurityConfig::default();
 
-        // `..` only survives canonicalization when an intermediate directory does not
-        // exist — the branch's own comment says so, and `/var/..` resolves cleanly, so a
-        // path built from real directories takes the OutsideRoot arm instead.
-        let WritePathDecision::Denied(msg) =
-            classify_write_path("no-such-dir-xyz/../escape.rs", tmp.path(), &cfg, &[])
-        else {
+        // `..` only survives canonicalization when the FINAL directory it resolves
+        // to (after collapsing `..`) still doesn't exist — not merely when an
+        // intermediate segment is missing. On Windows, `CreateFileW`'s NT path
+        // translation lexically collapses `dir/..` pairs before any filesystem
+        // lookup happens, so a single missing intermediate (`no-such-dir-xyz/..`)
+        // resolves cleanly there even though it fails on POSIX's component-wise
+        // `readdir` walk. Nesting a SECOND missing directory after the collapse
+        // (`.../also-missing/`) defeats both: Windows collapses the first `..`
+        // and then fails to canonicalize `also-missing` (which genuinely doesn't
+        // exist), and POSIX fails at `no-such-dir-xyz` before ever reaching `..`.
+        // Either way `best_effort_canonicalize` falls back to the raw, unresolved
+        // path, so this input takes the hard-Denied arm on every platform.
+        let WritePathDecision::Denied(msg) = classify_write_path(
+            "no-such-dir-xyz/../also-missing/escape.rs",
+            tmp.path(),
+            &cfg,
+            &[],
+        ) else {
             // If this ever classifies differently the message contract still needs a home;
             // fail loudly rather than skipping the assertion.
             panic!("an unresolved '..' must be a hard Denied, not approvable");


### PR DESCRIPTION
## Summary
- First-ever full `cargo test`/`clippy` run on a native Windows (gnu) toolchain for this repo surfaced 14 failures. This PR fixes all of them plus one unrelated pre-existing clippy gate failure discovered during verification.
- 6 genuine bugs fixed (production code): rendezvous `parent_pid()` was a hardcoded `0` stub on Windows — real PPID detection now implemented via a ToolHelp32 snapshot walk (`windows-sys`). `outside_roots_group()` (doctor) silently corrupted POSIX-style paths with backslashes on Windows. `artifact(action="create")` emitted `abs_path` without forward-slash normalization, breaking Windows tracker-guide routing. A test was missing an `EnvGuard`, hitting ambient embedder config. Plus 2 fallout test fixes the `to_forward_slash` change exposed. Plus an unrelated pre-existing `missing_const_for_thread_local` clippy false-positive on a test-only `thread_local!`.
- 9 further failures needed **no production change**, and they are not all one cluster:
  - **8 are pre-existing POSIX-only test assumptions** (hardcoded `/tmp/...` literals, `..`-collapse semantics, `Path::is_absolute()` differences, `\?\`-verbatim path fixtures) never previously exercised on native Windows.
  - **1 is not a Windows issue at all.** `memory::filter::tests::filter_sections_empty_sections_is_caller_error` is a `#[should_panic]` test over a `debug_assert!`, which `--release` compiles out — so it fails identically on **any** OS under `--release`, and only surfaced here because this run used `--release`. Gated with `#[cfg(debug_assertions)]`. (Reproduced failing on Linux/`experiments` under `--release` during review.)
- Independently verified the two `path_security` cases are not a security bypass by tracing actual Windows path-canonicalization behavior against `classify_write_path`/`check_source_file_access`, not just patching until green. Re-confirmed in review: a rooted-but-driveless path (`/etc/passwd`) is not `is_absolute()` on Windows, but Rust's `PathBuf::join` reproduces Windows drive-relative semantics (`C:\proj`.join(`/etc/passwd`) → `C:\etc\passwd`), so it lands as `OutsideRoot` / not-in-project. The failure direction is over-strict, never permissive.

## Bug files
All in `docs/issues/`, each with full root-cause analysis, evidence, and fix citations:
- `2026-08-19-rendezvous-parent-pid-stub-returns-zero-on-windows.md`
- `2026-08-19-doctor-outside-roots-group-rewrites-posix-paths-with-backslashes.md`
- `2026-08-19-artifact-create-abs-path-missing-forward-slash-normalization.md`
- `2026-08-19-memory-embedder-test-missing-envguard-for-embedder-url.md`
- `2026-08-19-windows-native-test-suite-posix-path-assumptions.md` (bundled, 9 tests)
- `2026-08-19-event-create-test-thread-local-missing-clippy-allow.md`

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --release --features server-stack --all-targets -- -D warnings` — clean
- [x] `cargo test --release --features server-stack --lib` — **4016 passed, 0 failed, 17 ignored**
- [x] Verified on native Windows, `1.97.1-x86_64-pc-windows-gnu` toolchain (this VDI has no MSVC C++ Build Tools)

## Linux cross-verification (added in review)
- [x] `cargo check --target x86_64-pc-windows-gnu --lib --features server-stack` on Linux — **clean, 54s**. Worth standing up as a CI job: `parent_pid()` exists only under `#[cfg(windows)]`, so Linux CI cannot compile that arm at all — which is how a hardcoded `0` stub survived there indefinitely.
- [x] `cargo test --features server-stack --lib` on Linux — **4087 passed**, no regressions attributable to this branch.
- [x] `outside_roots_group` old-vs-new implementations compared across 18 inputs: identical on every well-formed catalog row (POSIX and forward-slash Windows alike); diverging only on malformed input (trailing slash, `.` component), which is display-grouping only — the sole caller is a `HashMap::entry` key.

## Added in review
- `outside_roots_group_keeps_the_forward_slash_form_the_catalog_stores` — the existing two tests use POSIX literals only, so nothing covered the drive-lettered (`C:/…`) row shape that the Windows catalog actually stores now that `to_forward_slash` normalizes `abs_path`. Asserts the group key stays backslash-free and remains a prefix of the row it groups. Verified non-vacuous: under a backslash-rendering mutation of `outside_roots_group` it fails with `C:/work/proj/docs/trackers/x.md -> C:\work\proj`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
